### PR TITLE
Clean up unused package strings when registering strings

### DIFF
--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -20,6 +20,8 @@ class WPML_Gutenberg_Integration {
 
 		if ( self::PACKAGE_ID === $package_data['kind'] ) {
 
+			do_action( 'wpml_start_string_package_registration', $package_data );
+
 			$blocks = gutenberg_parse_blocks( $post->post_content );
 
 			foreach ( $blocks as $block ) {
@@ -38,6 +40,9 @@ class WPML_Gutenberg_Integration {
 
 				}
 			}
+
+			do_action( 'wpml_delete_unused_package_strings', $package_data );
+
 		}
 	}
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -91,6 +91,9 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 			);
 		}
 
+		\WP_Mock::expectAction( 'wpml_start_string_package_registration', $package );
+		\WP_Mock::expectAction( 'wpml_delete_unused_package_strings', $package );
+
 		$subject->register_strings( $post, $package );
 
 	}


### PR DESCRIPTION
Clean up unused package strings when registering strings - https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5644