### PR TITLE
Don't include gutenberg columns and column inner HTML in translation editor

### DIFF
--- a/src/class-wpml-gutenberg-config-option.php
+++ b/src/class-wpml-gutenberg-config-option.php
@@ -16,7 +16,7 @@ class WPML_Gutenberg_Config_Option {
 		if ( isset( $config_data['wpml-config']['gutenberg-blocks']['gutenberg-block'] ) ) {
 			foreach ( $config_data['wpml-config']['gutenberg-blocks']['gutenberg-block'] as $block_config ) {
 				$blocks[ $block_config['attr']['type'] ] = array();
-				if( 'true' === $block_config['attr']['has-strings'] && isset( $block_config['xpath'] ) ) {
+				if( '1' === $block_config['attr']['translate'] && isset( $block_config['xpath'] ) ) {
 					foreach ( $block_config['xpath'] as $xpaths ) {
 						if ( is_array( $xpaths ) ) {
 							$blocks[ $block_config['attr']['type'] ] = array_merge( $blocks[ $block_config['attr']['type'] ], array_values( $xpaths ) );

--- a/src/class-wpml-gutenberg-config-option.php
+++ b/src/class-wpml-gutenberg-config-option.php
@@ -16,11 +16,13 @@ class WPML_Gutenberg_Config_Option {
 		if ( isset( $config_data['wpml-config']['gutenberg-blocks']['gutenberg-block'] ) ) {
 			foreach ( $config_data['wpml-config']['gutenberg-blocks']['gutenberg-block'] as $block_config ) {
 				$blocks[ $block_config['attr']['type'] ] = array();
-				foreach ( $block_config['xpath'] as $xpaths ) {
-					if ( is_array( $xpaths ) ) {
-						$blocks[ $block_config['attr']['type'] ] = array_merge( $blocks[ $block_config['attr']['type'] ], array_values( $xpaths ) );
-					} else {
-						$blocks[ $block_config['attr']['type'] ][] = $xpaths;
+				if( 'true' === $block_config['attr']['has-strings'] && isset( $block_config['xpath'] ) ) {
+					foreach ( $block_config['xpath'] as $xpaths ) {
+						if ( is_array( $xpaths ) ) {
+							$blocks[ $block_config['attr']['type'] ] = array_merge( $blocks[ $block_config['attr']['type'] ], array_values( $xpaths ) );
+						} else {
+							$blocks[ $block_config['attr']['type'] ][] = $xpaths;
+						}
 					}
 				}
 			}

--- a/src/class-wpml-gutenberg-strings-in-block.php
+++ b/src/class-wpml-gutenberg-strings-in-block.php
@@ -25,7 +25,7 @@ class WPML_Gutenberg_Strings_In_Block {
 
 		$block_queries = $this->get_block_queries( $block );
 
-		if ( $block_queries ) {
+		if ( is_array( $block_queries ) ) {
 
 			$xpath = $this->get_domxpath( $block );
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-config-option.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-config-option.php
@@ -19,7 +19,7 @@ class Test_WPML_Gutenberg_Integration_Config_Option extends OTGS_TestCase {
 		$expected_block_path = array( 'xpath1', 'xpath2' );
 
 		$block_data = array(
-			'attr' => array( 'type' => $block_type ),
+			'attr' => array( 'type' => $block_type, 'has-strings' => 'true' ),
 			'xpath' => $block_xpath,
 		);
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-config-option.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-config-option.php
@@ -19,7 +19,7 @@ class Test_WPML_Gutenberg_Integration_Config_Option extends OTGS_TestCase {
 		$expected_block_path = array( 'xpath1', 'xpath2' );
 
 		$block_data = array(
-			'attr' => array( 'type' => $block_type, 'has-strings' => 'true' ),
+			'attr' => array( 'type' => $block_type, 'translate' => '1' ),
 			'xpath' => $block_xpath,
 		);
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-stings-in-block.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-stings-in-block.php
@@ -59,6 +59,27 @@ class Test_WPML_Gutenberg_Strings_In_Block extends OTGS_TestCase {
 	/**
 	 * @test
 	 */
+	public function it_does_not_find_column_if_there_is_no_xpath() {
+
+		$config_option = \Mockery::mock( 'WPML_Gutenberg_Config_Option' );
+		$config_option->shouldReceive( 'get' )
+		              ->andReturn( array( 'core/column' => array() ) );
+
+		$strings_in_block = new WPML_Gutenberg_Strings_In_Block( $config_option );
+
+		$block = array(
+			'blockName' => 'core/column',
+			'innerHTML' => 'any data',
+		);
+
+		$strings = $strings_in_block->find( $block );
+
+		$this->assertCount( 0, $strings );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_finds_image() {
 		$config_option = \Mockery::mock( 'WPML_Gutenberg_Config_Option' );
 		$config_option->shouldReceive( 'get' )


### PR DESCRIPTION
Don't include gutenberg columns and column inner HTML in translation editor - https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5685