### PR TITLE
Decode HTML entities in the strings to translate

### DIFF
--- a/src/class-wpml-gutenberg-strings-in-block.php
+++ b/src/class-wpml-gutenberg-strings-in-block.php
@@ -151,6 +151,10 @@ class WPML_Gutenberg_Strings_In_Block {
 			$type = 'VISUAL';
 		}
 
+		if ( 'VISUAL' !== $type ) {
+			$innerHTML = html_entity_decode( $innerHTML );
+		}
+
 		return array( $innerHTML, $type );
 	}
 


### PR DESCRIPTION
This applies only for LINE and AREA because VISUAL fields will be
automatically decoded by TinyMCE.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6066