### PR TITLE
Do not register strings from the block editor if the content has no block

### DIFF
--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -59,6 +59,10 @@ class WPML_Gutenberg_Integration {
 	 */
 	function register_strings( WP_Post $post, $package_data ) {
 
+		if ( ! $this->is_gutenberg_post( $post ) ) {
+			return;
+		}
+
 		if ( self::PACKAGE_ID === $package_data['kind'] ) {
 
 			do_action( 'wpml_start_string_package_registration', $package_data );

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -57,11 +57,40 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_not_register_strings_if_not_a_post_built_with_the_block_editor() {
+		$subject = $this->get_subject();
+
+		$post               = \Mockery::mock( 'WP_Post' );
+		$post->post_content = 'post content with no block meta comment';
+
+		$package = array(
+			'kind' => WPML_Gutenberg_Integration::PACKAGE_ID,
+		);
+
+		\WP_Mock::userFunction( 'gutenberg_parse_blocks',
+			array(
+				'times'  => 0,
+			)
+		);
+
+		\WP_Mock::userFunction( 'parse_blocks',
+			array(
+				'times'  => 0,
+			)
+		);
+
+		$subject->register_strings( $post, $package );
+
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_registers_strings() {
 		$subject = $this->get_subject();
 
 		$post               = \Mockery::mock( 'WP_Post' );
-		$post->post_content = 'post content';
+		$post->post_content = '<!-- wp:something -->post content<!-- /wp:something -->';
 
 		$package = array(
 			'kind' => WPML_Gutenberg_Integration::PACKAGE_ID,


### PR DESCRIPTION
WP block parser wraps the raw HTML (with no meta-comment) into a block.
So we were creating a string with the whole post content in that case (side effect of wpmlcore-6075).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6083