### PR TITLE
Force to update the post content in the target language

### DIFF
--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -3,12 +3,15 @@
 class WPML_Gutenberg_Integration_Factory {
 
 	public function create() {
+		/** @var SitePress $sitepress */
+		global $sitepress;
 
 		$config_option = new WPML_Gutenberg_Config_Option();
 
 		return new WPML_Gutenberg_Integration(
 			new WPML_Gutenberg_Strings_In_Block( $config_option ),
-			$config_option
+			$config_option,
+			$sitepress
 		);
 	}
 }

--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -21,17 +21,18 @@ class WPML_Gutenberg_Integration {
 	private $config_option;
 
 	/**
-	 * WPML_Gutenberg_Integration constructor.
-	 *
-	 * @param WPML_Gutenberg_Strings_In_Block $strings_in_block
-	 * @param WPML_Gutenberg_Config_Option $config_option
+	 * @var SitePress
 	 */
+	private $sitepress;
+
 	public function __construct(
 		WPML_Gutenberg_Strings_In_Block $strings_in_block,
-		WPML_Gutenberg_Config_Option $config_option
+		WPML_Gutenberg_Config_Option $config_option,
+		SitePress $sitepress
 	) {
 		$this->strings_in_blocks = $strings_in_block;
 		$this->config_option     = $config_option;
+		$this->sitepress         = $sitepress;
 	}
 
 	public function add_hooks() {
@@ -151,8 +152,9 @@ class WPML_Gutenberg_Integration {
 				$content .= $this->render_block( $block );
 			}
 
+			$this->sitepress->switch_lang( $lang );
 			wp_update_post( array( 'ID' => $translated_post_id, 'post_content' => $content ) );
-
+			$this->sitepress->switch_lang( null );
 		}
 
 	}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -12,8 +12,14 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_creates() {
+		global $sitepress;
+
+		$sitepress = \Mockery::mock( 'SitePress' );
+
 		$factory = new WPML_Gutenberg_Integration_Factory();
 
 		$this->assertInstanceOf( 'WPML_Gutenberg_Integration', $factory->create() );
+
+		unset( $sitepress );
 	}
 }


### PR DESCRIPTION
We have a filter `WPML_Term_Adjust_Id::filter` which is messing the terms
when we are saving the post content. Sometimes it converts the
translated terms into the source ones (because the current lang is the
original one).

The filter is relying on several debug backtrace conditions which are
impacted depending on the activated page builders (e.g. we have a
problem when Enfold + Gutenberg are enabled, but not when only Gutenberg
is enabled).

By saving in the target lang, we ensure the terms are not messed even if
it's filtered.

Moreover, at this step we should not have nested post save so we should
not have side effects.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6221