### PR TITLE
Improve handling of Inner blocks in Gutenberg

### DIFF
--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -12,9 +12,10 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_creates() {
-		global $sitepress;
+		global $sitepress, $wpdb;
 
 		$sitepress = \Mockery::mock( 'SitePress' );
+		$wpdb      = \Mockery::mock( 'wpdb' );
 		\Mockery::mock( 'WPML_ST_String_Factory' );
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
 		\Mockery::mock( 'WPML_PB_String_Translation' );

--- a/tests/phpunit/tests/test-wpml-gutenberg-string-registration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-string-registration.php
@@ -209,7 +209,7 @@ class Test_WPML_Gutenberg_String_Registration extends OTGS_TestCase {
 		$strings_in_block   = new WPML_Gutenberg_Strings_In_Block( $config_option );
 		$string_factory     = $string_factory ? $string_factory : $this->get_string_factory();
 		$reuse_translations = $reuse_translations ? $reuse_translations : $this->get_reuse_translation();
-		$string_translation = $string_translation ? $string_translation : $this->get_string_translation();
+		$string_translation = $string_translation ? $string_translation : $this->get_string_translation( true );
 
 		return new WPML_Gutenberg_Strings_Registration( $strings_in_block, $string_factory, $reuse_translations, $string_translation );
 	}
@@ -240,11 +240,15 @@ class Test_WPML_Gutenberg_String_Registration extends OTGS_TestCase {
 			->disableOriginalConstructor()->getMock();
 	}
 
-	private function get_string_translation() {
+	private function get_string_translation( $passthru = false ) {
 		$string_translation = $this->getMockBuilder( 'WPML_PB_String_Translation' )
             ->setMethods( array( 'get_package_strings', 'get_string_hash' ) )
             ->disableOriginalConstructor()->getMock();
 		$string_translation->method( 'get_string_hash' )->willReturnCallback( array( $this, 'get_string_hash' ) );
+
+		if ( $passthru ) {
+			$string_translation->method( 'get_package_strings' )->willReturn( array() );
+		}
 
 		return $string_translation;
 	}


### PR DESCRIPTION
We can now use a new property `WP_Block_Parser_Block::$innerContent`
which provides the sequence of inner elements: strings or
null if it's an inner block.

Then we just need to replace the null value with inner blocks.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6330