### PR TITLE
Include the reusable string packages in the translation job of the document it's inserted in.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   },
   "require": {
     "roave/security-advisories": "dev-master",
-    "jakeasmith/http_build_url": "^1.0"
+    "jakeasmith/http_build_url": "^1.0",
+    "tightenco/collect": "5.3.20"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",

--- a/src/class-integration-composite.php
+++ b/src/class-integration-composite.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Integration_Composite implements Integration {
+
+	/**
+	 * @var Integration[] $integrations
+	 */
+	private $integrations;
+
+	/**
+	 * @param Integration[] $integrations
+	 */
+	public function __construct( array $integrations ) {
+		$this->integrations = $integrations;
+	}
+
+	public function add_hooks() {
+		foreach ( $this->integrations as $integration ) {
+
+			if ( ! $integration instanceof Integration ) {
+				throw new \Exception( 'The class ' . get_class( $integration ) . ' must implement the Integration interface' );
+			}
+
+			$integration->add_hooks();
+		}
+	}
+
+}

--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -2,12 +2,15 @@
 
 class WPML_Gutenberg_Integration_Factory {
 
+	/** @return \WPML\PB\Gutenberg\Integration */
 	public function create() {
 		/**
 		 * @var SitePress $sitepress
 		 * @var wpdb      $wpdb
 		 */
 		global $sitepress, $wpdb;
+
+		$integrations = [];
 
 		$config_option        = new WPML_Gutenberg_Config_Option();
 		$strings_in_block     = new WPML_Gutenberg_Strings_In_Block( $config_option );
@@ -19,11 +22,17 @@ class WPML_Gutenberg_Integration_Factory {
 			new WPML_PB_String_Translation( $wpdb )
 		);
 
-		return new WPML_Gutenberg_Integration(
+		$integrations[] = new WPML_Gutenberg_Integration(
 			$strings_in_block,
 			$config_option,
 			$sitepress,
 			$strings_registration
 		);
+
+		$integrations[] = new WPML\PB\Gutenberg\Reusable_Blocks_Integration(
+			new WPML\PB\Gutenberg\Reusable_Blocks()
+		);
+
+		return new WPML\PB\Gutenberg\Integration_Composite( $integrations );
 	}
 }

--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -3,7 +3,7 @@
 /**
  * Class WPML_Gutenberg_Integration
  */
-class WPML_Gutenberg_Integration {
+class WPML_Gutenberg_Integration implements \WPML\PB\Gutenberg\Integration {
 
 	const PACKAGE_ID              = 'Gutenberg';
 	const GUTENBERG_OPENING_START = '<!-- wp:';

--- a/src/interface-integration.php
+++ b/src/interface-integration.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+interface Integration {
+
+	public function add_hooks();
+}

--- a/src/reusable-blocks/class-reusable-blocks-integration.php
+++ b/src/reusable-blocks/class-reusable-blocks-integration.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Reusable_Blocks_Integration implements Integration{
+
+	/** @var Reusable_Blocks $reusable_blocks */
+	private $reusable_blocks;
+
+	public function __construct( Reusable_Blocks $reusable_blocks ) {
+		$this->reusable_blocks = $reusable_blocks;
+	}
+
+	public function add_hooks() {
+		add_filter( 'wpml_st_get_post_string_packages', [ $this, 'add_reusable_block_packages' ], PHP_INT_MAX, 2 );
+	}
+
+	/**
+	 * @param array $packages
+	 * @param int   $post_id
+	 *
+	 * @return array
+	 */
+	public function add_reusable_block_packages( $packages, $post_id ) {
+		remove_filter( 'wpml_st_get_post_string_packages', [ $this, 'add_reusable_block_packages' ], PHP_INT_MAX );
+
+		foreach ( $this->reusable_blocks->get_ids( $post_id ) as $block_id ) {
+			$block_packages = apply_filters( 'wpml_st_get_post_string_packages', [], $block_id );
+			$packages       = $packages + $block_packages;
+		}
+
+		add_filter( 'wpml_st_get_post_string_packages', [ $this, 'add_reusable_block_packages' ], PHP_INT_MAX, 2 );
+
+		return $packages;
+	}
+}

--- a/src/reusable-blocks/class-reusable-blocks.php
+++ b/src/reusable-blocks/class-reusable-blocks.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Reusable_Blocks {
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return array
+	 */
+	public function get_ids( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( $post ) {
+			$blocks = \collect( \WPML_Gutenberg_Integration::parse_blocks( $post->post_content ) );
+
+			return $blocks->filter( function( $block ) {
+				return 'core/block' === $block['blockName']
+				       && isset( $block['attrs']['ref'] )
+				       && is_numeric( $block['attrs']['ref'] );
+			})->map( function( $block ) {
+				return (int) $block['attrs']['ref'];
+			})->toArray();
+		}
+
+		return [];
+	}
+}

--- a/tests/phpunit/tests/reusable-blocks/test-reusable-blocks-integration.php
+++ b/tests/phpunit/tests/reusable-blocks/test-reusable-blocks-integration.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+/**
+ * @group reusable-blocks
+ */
+class Test_Reusable_Blocks_Integration extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_integration_interface() {
+		$this->assertInstanceOf( Integration::class, $this->get_subject() );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6563
+	 */
+	public function it_should_add_hooks() {
+		$subject = $this->get_subject();
+
+		\WP_Mock::expectFilterAdded( 'wpml_st_get_post_string_packages', [ $subject, 'add_reusable_block_packages' ], PHP_INT_MAX, 2 );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6563
+	 */
+	public function it_should_add_reusable_block_packages() {
+		$packages          = [ 1230 => 'package 1230' ];
+		$post_id           = 123;
+		$reusable_block_id = 456;
+
+		$reusable_block_packages = [ 4560 => 'package 4560' ];
+
+		$expected_packages = $packages + $reusable_block_packages;
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( [], $reusable_block_id )
+			->reply( $reusable_block_packages );
+
+		$reusable_blocks = $this->get_reusable_blocks();
+		$reusable_blocks->method( 'get_ids' )->with( $post_id )->willReturn( [ $reusable_block_id ] );
+
+		$subject = $this->get_subject( $reusable_blocks );
+
+		\WP_Mock::userFunction( 'remove_filter', [
+			'times' => 1,
+			'args'  => [ 'wpml_st_get_post_string_packages', [ $subject, 'add_reusable_block_packages' ], PHP_INT_MAX ],
+		]);
+
+		\WP_Mock::expectFilterAdded( 'wpml_st_get_post_string_packages', [ $subject, 'add_reusable_block_packages' ], PHP_INT_MAX, 2 );
+
+		$actual_packages = $subject->add_reusable_block_packages( $packages, $post_id );
+
+		$this->assertCount( 2, $actual_packages );
+		$this->assertArrayHasKey( 1230, $actual_packages );
+		$this->assertArrayHasKey( 4560, $actual_packages );
+		$this->assertEquals( $expected_packages, $actual_packages );
+	}
+
+	private function get_subject( $reusable_blocks = null ) {
+		$reusable_blocks = $reusable_blocks ? $reusable_blocks : $this->get_reusable_blocks();
+		return new Reusable_Blocks_Integration( $reusable_blocks );
+	}
+
+	private function get_reusable_blocks() {
+		return $this->getMockBuilder( '\WPML\PB\Gutenberg\Reusable_Blocks' )
+			->setMethods( [ 'get_ids' ] )
+			->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/reusable-blocks/test-reusable-blocks.php
+++ b/tests/phpunit/tests/reusable-blocks/test-reusable-blocks.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+/**
+ * @group reusable-blocks
+ */
+class Test_Reusable_Blocks extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @group wpmlcore-6563
+	 */
+	public function it_should_get() {
+		$GLOBALS['wp_version'] = '5.1.0';
+
+		$post_id  = 123;
+		$block_id = 456;
+
+		$post = $this->getMockBuilder( 'WP_Post' )
+			->disableOriginalConstructor()->getMock();
+		$post->post_content = 'some block content';
+
+		$blocks = [
+			// Valid reusable block
+			[
+				'blockName' => 'core/block',
+				'attrs'     => [ 'ref' => (string) $block_id ],
+			],
+			// Not wp block
+			[
+				'blockName' => 'not-wp/block',
+				'attrs'     => [ 'ref' => 987 ],
+			],
+			// Not numerical ref
+			[
+				'blockName' => 'core/block',
+				'attrs'     => [ 'ref' => 'something' ],
+			],
+			// No "ref"
+			[
+				'blockName' => 'core/block',
+				'attrs'     => [ 'foo' => 'bar' ],
+			],
+			// No "attrs"
+			[
+				'blockName' => 'core/block',
+			],
+		];
+
+		\WP_Mock::userFunction( 'get_post', [
+			'args'   => [ $post_id ],
+			'return' => $post,
+		]);
+
+		\WP_Mock::userFunction( 'parse_blocks', [
+			'args'   => [ $post->post_content ],
+			'return' => $blocks,
+		]);
+
+		$subject = new Reusable_Blocks();
+
+		$this->assertEquals(
+			[ $block_id ],
+			$subject->get_ids( $post_id )
+		);
+
+		unset( $GLOBALS['wp_version'] );
+	}
+}

--- a/tests/phpunit/tests/test-integration-composite.php
+++ b/tests/phpunit/tests/test-integration-composite.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Test_Integration_Composite extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_integration_interface() {
+		$this->assertInstanceOf( Integration::class, new Integration_Composite( [] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_hooks() {
+		$integration1 = $this->get_integration( true );
+		$integration2 = $this->get_integration( true );
+
+		$subject = new Integration_Composite( [ $integration1, $integration2 ] );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 * @expectedException \Exception
+	 */
+	public function it_should_throw_an_exception_if_one_class_does_not_implement_integration_interface() {
+		$integration1 = $this->get_integration( false );
+		$integration2 = $this->getMockBuilder( 'SomeClass' )->getMock();
+
+		$subject = new Integration_Composite( [ $integration1, $integration2 ] );
+
+		$subject->add_hooks();
+	}
+
+	private function get_integration( $expect_add_hooks ) {
+		$integration = $this->getMockBuilder( Integration::class )
+		                    ->setMethods( [ 'add_hooks' ] )
+		                    ->disableOriginalConstructor()->getMock();
+
+		if ( $expect_add_hooks ) {
+			$integration->expects( $this->once() )->method( 'add_hooks' );
+		}
+
+		return $integration;
+	}
+}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -22,7 +22,7 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 
 		$factory = new WPML_Gutenberg_Integration_Factory();
 
-		$this->assertInstanceOf( 'WPML_Gutenberg_Integration', $factory->create() );
+		$this->assertInstanceOf( \WPML\PB\Gutenberg\Integration::class, $factory->create() );
 
 		unset( $sitepress );
 	}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -11,6 +11,13 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_implement_integration_interface() {
+		$this->assertInstanceOf( \WPML\PB\Gutenberg\Integration::class, $this->get_subject() );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_adds_hooks() {
 		\Mockery::mock( 'WP_Post' );
 


### PR DESCRIPTION
When the reusable block is saved, strings will be created in a package
attached to the reusable block ID. We will add this package to the main
package of strings attached to the post we are translating.

In order to have a better organization of the code and decoupling, I
created the `Integration_Composite` class, so we can load several
integration classes.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6563