### PR TITLE
Convert the reusable block ID on the fly when it's rendered

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   },
   "require": {
     "roave/security-advisories": "dev-master",
-    "jakeasmith/http_build_url": "^1.0"
+    "jakeasmith/http_build_url": "^1.0",
+    "tightenco/collect": "5.3.20"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",

--- a/src/class-integration-composite.php
+++ b/src/class-integration-composite.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Integration_Composite implements Integration {
+
+	/**
+	 * @var Integration[] $integrations
+	 */
+	private $integrations;
+
+	public function add( Integration $integration ) {
+		$this->integrations[] = $integration;
+	}
+	public function add_hooks() {
+		foreach ( $this->integrations as $integration ) {
+			$integration->add_hooks();
+		}
+	}
+
+}

--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -2,12 +2,15 @@
 
 class WPML_Gutenberg_Integration_Factory {
 
+	/** @return \WPML\PB\Gutenberg\Integration */
 	public function create() {
 		/**
 		 * @var SitePress $sitepress
 		 * @var wpdb      $wpdb
 		 */
 		global $sitepress, $wpdb;
+
+		$integrations = new WPML\PB\Gutenberg\Integration_Composite();
 
 		$config_option        = new WPML_Gutenberg_Config_Option();
 		$strings_in_block     = new WPML_Gutenberg_Strings_In_Block( $config_option );
@@ -19,11 +22,21 @@ class WPML_Gutenberg_Integration_Factory {
 			new WPML_PB_String_Translation( $wpdb )
 		);
 
-		return new WPML_Gutenberg_Integration(
-			$strings_in_block,
-			$config_option,
-			$sitepress,
-			$strings_registration
+		$integrations->add(
+			new WPML_Gutenberg_Integration(
+				$strings_in_block,
+				$config_option,
+				$sitepress,
+				$strings_registration
+			)
 		);
+
+		$integrations->add(
+			new WPML\PB\Gutenberg\Reusable_Blocks_Integration(
+				new WPML\PB\Gutenberg\Reusable_Blocks_Translation( $sitepress )
+			)
+		);
+
+		return $integrations;
 	}
 }

--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -3,7 +3,7 @@
 /**
  * Class WPML_Gutenberg_Integration
  */
-class WPML_Gutenberg_Integration {
+class WPML_Gutenberg_Integration implements \WPML\PB\Gutenberg\Integration {
 
 	const PACKAGE_ID              = 'Gutenberg';
 	const GUTENBERG_OPENING_START = '<!-- wp:';
@@ -140,9 +140,6 @@ class WPML_Gutenberg_Integration {
 			$block = self::sanitize_block( $block );
 			$block = $this->strings_in_blocks->update( $block, $string_translations, $lang );
 
-			if ( isset( $block->blockName ) && 'core/block' === $block->blockName ) {
-				$block->attrs['ref'] = apply_filters( 'wpml_object_id', $block->attrs['ref'], 'wp_block', true, $lang );
-			}
 			if ( isset( $block->innerBlocks ) ) {
 				$block->innerBlocks = $this->update_block_translations(
 					$block->innerBlocks,

--- a/src/interface-integration.php
+++ b/src/interface-integration.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+interface Integration {
+
+	public function add_hooks();
+}

--- a/src/reusable-blocks/class-reusable-blocks-integration.php
+++ b/src/reusable-blocks/class-reusable-blocks-integration.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Reusable_Blocks_Integration implements Integration{
+
+	/** @var Reusable_Blocks_Translation $reusable_blocks_translation */
+	private $reusable_blocks_translation;
+
+	public function __construct(
+		Reusable_Blocks_Translation $reusable_blocks_translation
+	) {
+		$this->reusable_blocks_translation = $reusable_blocks_translation;
+	}
+
+	public function add_hooks() {
+		add_filter( 'render_block_data', [ $this, 'convert_reusable_block' ] );
+	}
+
+	/**
+	 * Converts the block in the current language
+	 *
+	 * @param array $block
+	 *
+	 * @return array
+	 */
+	public function convert_reusable_block( array $block ) {
+		return $this->reusable_blocks_translation->convert_block( $block );
+	}
+}

--- a/src/reusable-blocks/class-reusable-blocks-translation.php
+++ b/src/reusable-blocks/class-reusable-blocks-translation.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Reusable_Blocks_Translation {
+
+	const POST_TYPE = 'wp_block';
+
+	/** @var \SitePress $sitepress */
+	private $sitepress;
+
+	/**
+	 * @param \SitePress $sitepress
+	 */
+	public function __construct( \SitePress $sitepress ) {
+		$this->sitepress = $sitepress;
+	}
+
+	/**
+	 * @param array        $block
+	 * @param null|string  $lang
+	 *
+	 * @return array
+	 */
+	public function convert_block( array $block, $lang = null ) {
+		if ( Reusable_Blocks::is_reusable( $block ) ) {
+			$block['attrs']['ref'] = $this->sitepress->get_object_id(
+				$block['attrs']['ref'],
+				self::POST_TYPE,
+				true,
+				$lang
+			);
+		}
+
+		return $block;
+	}
+}

--- a/src/reusable-blocks/class-reusable-blocks.php
+++ b/src/reusable-blocks/class-reusable-blocks.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Reusable_Blocks {
+
+	/**
+	 * @param array $block
+	 *
+	 * @return bool
+	 */
+	public static function is_reusable( array $block ) {
+		return 'core/block' === $block['blockName']
+		       && isset( $block['attrs']['ref'] )
+		       && is_numeric( $block['attrs']['ref'] );
+	}
+}

--- a/tests/phpunit/tests/reusable-blocks/test-reusable-blocks-integration.php
+++ b/tests/phpunit/tests/reusable-blocks/test-reusable-blocks-integration.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+/**
+ * @group reusable-blocks
+ */
+class Test_Reusable_Blocks_Integration extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_integration_interface() {
+		$this->assertInstanceOf( Integration::class, $this->get_subject() );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6563
+	 */
+	public function it_should_add_hooks() {
+		$subject = $this->get_subject();
+
+		\WP_Mock::expectFilterAdded( 'render_block_data', [ $subject, 'convert_reusable_block' ] );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6565
+	 */
+	public function it_should_convert_reusable_block() {
+		$block           = [ 'block with original ref' ];
+		$converted_block = [ 'block with ref converted in the current lang' ];
+
+		$reusable_blocks_translation = $this->get_reusable_blocks_translation();
+		$reusable_blocks_translation->method( 'convert_block' )
+			->with( $block )->willReturn( $converted_block );
+
+		$subject = $this->get_subject( $reusable_blocks_translation );
+
+		$this->assertEquals(
+			$converted_block,
+			$subject->convert_reusable_block( $block )
+		);
+	}
+
+	private function get_subject( $reusable_blocks_translation = null ) {
+		$reusable_blocks_translation = $reusable_blocks_translation
+			? $reusable_blocks_translation : $this->get_reusable_blocks_translation();
+
+		return new Reusable_Blocks_Integration( $reusable_blocks_translation );
+	}
+
+	private function get_reusable_blocks_translation() {
+		return $this->getMockBuilder( '\WPML\PB\Gutenberg\Reusable_Blocks_Translation' )
+			->setMethods( [ 'create_post', 'convert_block' ] )
+			->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/reusable-blocks/test-reusable-blocks-translation.php
+++ b/tests/phpunit/tests/reusable-blocks/test-reusable-blocks-translation.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+/**
+ * @group reusable-blocks
+ */
+class Test_Reusable_Blocks_Translation extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dp_invalid_reusable_blocks
+	 * @group wpmlcore-6565
+	 *
+	 * @param array $block
+	 */
+	public function it_should_not_convert_block_if_not_a_reusable( $block ) {
+		$sitepress = $this->get_sitepress();
+		$sitepress->expects( $this->never() )->method( 'get_object_id' );
+
+		$subject = $this->get_subject( $sitepress );
+
+		$this->assertEquals(
+			$block,
+			$subject->convert_block( $block )
+		);
+	}
+
+	public static function dp_invalid_reusable_blocks() {
+		return [
+			'not reusable block' => [
+				[
+					'blockName' => 'not-wp/block',
+					'attrs'     => [ 'ref' => 987 ],
+				],
+			],
+			'not numerical ref' => [
+				[
+					'blockName' => 'core/block',
+					'attrs'     => [ 'ref' => 'something' ],
+				],
+			],
+			'no ref' => [
+				[
+					'blockName' => 'core/block',
+					'attrs'     => [ 'foo' => 'bar' ],
+				],
+			],
+			'no attrs' => [
+				[
+					'blockName' => 'core/block',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6565
+	 */
+	public function it_should_convert_block() {
+		$lang                = 'fr';
+		$original_block_id   = 123;
+		$translated_block_id = 456;
+
+		$block = [
+			'blockName' => 'core/block',
+			'attrs'     => [
+				'ref' => $original_block_id	,
+			],
+		];
+
+		$converted_block = [
+			'blockName' => 'core/block',
+			'attrs'     => [
+				'ref' => $translated_block_id	,
+			],
+		];
+
+		$sitepress = $this->get_sitepress();
+		$sitepress->method( 'get_object_id' )
+				->with( $original_block_id, Reusable_Blocks_Translation::POST_TYPE, true, $lang )
+				->willReturn( $translated_block_id );
+
+		$subject = $this->get_subject( $sitepress );
+
+		$this->assertEquals(
+			$converted_block,
+			$subject->convert_block( $block, $lang )
+		);
+	}
+	
+	private function get_subject( $sitepress = null ) {
+		$sitepress = $sitepress ? $sitepress : $this->get_sitepress();
+		return new Reusable_Blocks_Translation( $sitepress );
+	}
+
+	private function get_sitepress() {
+		return $this->getMockBuilder( \SitePress::class )
+			->setMethods( [ 'set_element_language_details', 'get_object_id' ] )
+			->disableOriginalConstructor()->getMock();
+	}
+}

--- a/tests/phpunit/tests/reusable-blocks/test-reusable-blocks.php
+++ b/tests/phpunit/tests/reusable-blocks/test-reusable-blocks.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+/**
+ * @group reusable-blocks
+ */
+class Test_Reusable_Blocks extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dp_invalid_reusable_blocks
+	 * @group wpmlcore-6565
+	 *
+	 * @param array $block
+	 */
+	public function it_should_return_false_if_NOT_reusable_block( $block ) {
+		$this->assertFalse( Reusable_Blocks::is_reusable( $block ) );
+
+	}
+
+	public static function dp_invalid_reusable_blocks() {
+		return [
+			'not reusable block' => [
+				[
+					'blockName' => 'not-wp/block',
+					'attrs'     => [ 'ref' => 987 ],
+				],
+			],
+			'not numerical ref' => [
+				[
+					'blockName' => 'core/block',
+					'attrs'     => [ 'ref' => 'something' ],
+				],
+			],
+			'no ref' => [
+				[
+					'blockName' => 'core/block',
+					'attrs'     => [ 'foo' => 'bar' ],
+				],
+			],
+			'no attrs' => [
+				[
+					'blockName' => 'core/block',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6565
+	 */
+	public function it_should_return_true_if_is_reusable_block() {
+		$block = [
+			'blockName' => 'core/block',
+			'attrs'     => [ 'ref' => 987 ],
+		];
+
+		$this->assertTrue( Reusable_Blocks::is_reusable( $block ) );
+	}
+}

--- a/tests/phpunit/tests/test-integration-composite.php
+++ b/tests/phpunit/tests/test-integration-composite.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WPML\PB\Gutenberg;
+
+class Test_Integration_Composite extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_integration_interface() {
+		$this->assertInstanceOf( Integration::class, new Integration_Composite( [] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_hooks() {
+		$subject = new Integration_Composite();
+
+		$subject->add( $this->get_integration( true ) );
+		$subject->add( $this->get_integration( true ) );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @param bool $expect_add_hooks
+	 *
+	 * @return \PHPUnit_Framework_MockObject_MockObject|Integration
+	 */
+	private function get_integration( $expect_add_hooks ) {
+		$integration = $this->getMockBuilder( Integration::class )
+		                    ->setMethods( [ 'add_hooks' ] )
+		                    ->disableOriginalConstructor()->getMock();
+
+		if ( $expect_add_hooks ) {
+			$integration->expects( $this->once() )->method( 'add_hooks' );
+		}
+
+		return $integration;
+	}
+}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -22,7 +22,7 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 
 		$factory = new WPML_Gutenberg_Integration_Factory();
 
-		$this->assertInstanceOf( 'WPML_Gutenberg_Integration', $factory->create() );
+		$this->assertInstanceOf( \WPML\PB\Gutenberg\Integration::class, $factory->create() );
 
 		unset( $sitepress );
 	}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -11,6 +11,13 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_implement_integration_interface() {
+		$this->assertInstanceOf( \WPML\PB\Gutenberg\Integration::class, $this->get_subject() );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_adds_hooks() {
 		\Mockery::mock( 'WP_Post' );
 


### PR DESCRIPTION
I decided to remove the code to convert the ID inside the translated
post because we would keep an invalid block ID if one day this
translated block is removed independently. Also, we'll have a consistent
way to convert the block accross all posts.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6565