### PR TITLE
Unicode is not escaped in Gutenberg block attributes

### DIFF
--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -170,7 +170,7 @@ class WPML_Gutenberg_Integration {
 
 			$block_attributes = '';
 			if ( $this->has_non_empty_attributes( $block ) ) {
-				$block_attributes = ' ' . json_encode( $block->attrs );
+				$block_attributes = ' ' . json_encode( $block->attrs, JSON_UNESCAPED_UNICODE );
 			}
 			$content .= self::GUTENBERG_OPENING_START . $block_type . $block_attributes . ' -->';
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -150,7 +150,7 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 
 		$block_name                  = 'some-block-name';
 		$core_block_name             = 'core/' . $block_name; // Gutenberg prefixes with 'core/'
-		$attributes                  = array( 'att_1' => 'value_1', 'att_2' => 'value_2' );
+		$attributes                  = array( 'att_1' => 'value_1', 'att_2' => 'value_2', 'att_3' => 'polish żółć' );
 		$original_block_inner_HTML   = 'some block content';
 		$translated_block_inner_HTML = 'some block content ( TRANSLATED )';
 
@@ -179,7 +179,7 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 			)
 		);
 
-		$rendered_block = '<!-- wp:' . $block_name . ' ' . json_encode( $attributes ) . ' -->' . $translated_block_inner_HTML . '<!-- /wp:' . $block_name . ' -->';
+		$rendered_block = '<!-- wp:' . $block_name . ' ' . json_encode( $attributes, JSON_UNESCAPED_UNICODE ) . ' -->' . $translated_block_inner_HTML . '<!-- /wp:' . $block_name . ' -->';
 
 		\WP_Mock::userFunction( 'wp_update_post',
 			array(


### PR DESCRIPTION
- added flag JSON_UNESCAPED_UNICODE to json_encode()

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6540