### PR TITLE
Do not load reusable block integration when it's not translatable

### DIFF
--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -31,27 +31,33 @@ class WPML_Gutenberg_Integration_Factory {
 			)
 		);
 
-		$reusable_blocks             = new WPML\PB\Gutenberg\ReusableBlocks\Blocks();
-		$reusable_blocks_translation = new WPML\PB\Gutenberg\ReusableBlocks\Translation( $sitepress );
-
-		$integrations->add(
-			new WPML\PB\Gutenberg\ReusableBlocks\Integration( $reusable_blocks_translation )
+		$is_reusable_block_translatable = $sitepress->is_translated_post_type(
+			WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE
 		);
 
-		if ( is_admin() ) {
+		if ( $is_reusable_block_translatable ) {
+			$reusable_blocks             = new WPML\PB\Gutenberg\ReusableBlocks\Blocks();
+			$reusable_blocks_translation = new WPML\PB\Gutenberg\ReusableBlocks\Translation( $sitepress );
+
 			$integrations->add(
-				new WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration(
-					new WPML\PB\Gutenberg\ReusableBlocks\ManageBatch(
-						$reusable_blocks,
-						$reusable_blocks_translation
-					),
-					new WPML\PB\Gutenberg\ReusableBlocks\ManageBasket(
-						$reusable_blocks,
-						$reusable_blocks_translation,
-						\WPML\Container\make( '\WPML_Translation_Basket' )
-					)
-				)
+				new WPML\PB\Gutenberg\ReusableBlocks\Integration( $reusable_blocks_translation )
 			);
+
+			if ( is_admin() ) {
+				$integrations->add(
+					new WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration(
+						new WPML\PB\Gutenberg\ReusableBlocks\ManageBatch(
+							$reusable_blocks,
+							$reusable_blocks_translation
+						),
+						new WPML\PB\Gutenberg\ReusableBlocks\ManageBasket(
+							$reusable_blocks,
+							$reusable_blocks_translation,
+							\WPML\Container\make( '\WPML_Translation_Basket' )
+						)
+					)
+				);
+			}
 		}
 
 		return $integrations;

--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -31,35 +31,35 @@ class WPML_Gutenberg_Integration_Factory {
 			)
 		);
 
-		$is_reusable_block_translatable = $sitepress->is_translated_post_type(
-			WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE
-		);
-
-		if ( $is_reusable_block_translatable ) {
-			$reusable_blocks             = new WPML\PB\Gutenberg\ReusableBlocks\Blocks();
-			$reusable_blocks_translation = new WPML\PB\Gutenberg\ReusableBlocks\Translation( $sitepress );
+		if ( $this->should_translate_reusable_blocks() ) {
+			WPML\Container\share(
+				[
+				  '\WPML\PB\Gutenberg\ReusableBlocks\Blocks',
+				  '\WPML\PB\Gutenberg\ReusableBlocks\Translation',
+				]
+			);
 
 			$integrations->add(
-				new WPML\PB\Gutenberg\ReusableBlocks\Integration( $reusable_blocks_translation )
+				WPML\Container\make( '\WPML\PB\Gutenberg\ReusableBlocks\Integration' )
 			);
 
 			if ( is_admin() ) {
 				$integrations->add(
-					new WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration(
-						new WPML\PB\Gutenberg\ReusableBlocks\ManageBatch(
-							$reusable_blocks,
-							$reusable_blocks_translation
-						),
-						new WPML\PB\Gutenberg\ReusableBlocks\ManageBasket(
-							$reusable_blocks,
-							$reusable_blocks_translation,
-							\WPML\Container\make( '\WPML_Translation_Basket' )
-						)
-					)
+					WPML\Container\make( '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration' )
 				);
 			}
 		}
 
 		return $integrations;
+	}
+
+	/** @return bool */
+	private function should_translate_reusable_blocks() {
+		/** @var SitePress $sitepress */
+		global $sitepress;
+
+		return $sitepress->is_translated_post_type(
+			WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE
+		);
 	}
 }

--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -32,13 +32,6 @@ class WPML_Gutenberg_Integration_Factory {
 		);
 
 		if ( $this->should_translate_reusable_blocks() ) {
-			WPML\Container\share(
-				[
-				  '\WPML\PB\Gutenberg\ReusableBlocks\Blocks',
-				  '\WPML\PB\Gutenberg\ReusableBlocks\Translation',
-				]
-			);
-
 			$integrations->add(
 				WPML\Container\make( '\WPML\PB\Gutenberg\ReusableBlocks\Integration' )
 			);

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -14,7 +14,7 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 	 *
 	 * @param bool $is_admin
 	 */
-	public function it_creates( $is_admin ) {
+	public function it_creates_when_reusable_blocks_are_NOT_translatable( $is_admin ) {
 		global $sitepress, $wpdb;
 
 		\WP_Mock::userFunction( 'is_admin', [
@@ -22,6 +22,45 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		] );
 
 		$sitepress = \Mockery::mock( 'SitePress' );
+		$sitepress->shouldReceive( 'is_translated_post_type' )
+		          ->with( WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE )
+		          ->andReturn( false );
+
+		$wpdb      = \Mockery::mock( 'wpdb' );
+		\Mockery::mock( 'WPML_ST_String_Factory' );
+		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		\Mockery::mock( 'WPML_PB_String_Translation' );
+
+		\WP_Mock::userFunction( 'WPML\Container\make', [
+			'args'   => [ '\WPML_Translation_Basket' ],
+			'return' => $this->getMockBuilder( '\WPML_Translation_Basket' )->getMock(),
+		] );
+
+		$factory = new WPML_Gutenberg_Integration_Factory();
+
+		$this->assertInstanceOf( \WPML\PB\Gutenberg\Integration::class, $factory->create() );
+
+		unset( $sitepress );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_is_admin
+	 *
+	 * @param bool $is_admin
+	 */
+	public function it_creates_when_reusable_blocks_are_translatable( $is_admin ) {
+		global $sitepress, $wpdb;
+
+		\WP_Mock::userFunction( 'is_admin', [
+			'return' => $is_admin,
+		] );
+
+		$sitepress = \Mockery::mock( 'SitePress' );
+		$sitepress->shouldReceive( 'is_translated_post_type' )
+		          ->with( WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE )
+		          ->andReturn( true );
+
 		$wpdb      = \Mockery::mock( 'wpdb' );
 		\Mockery::mock( 'WPML_ST_String_Factory' );
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -64,16 +64,6 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
 		\Mockery::mock( 'WPML_PB_String_Translation' );
 
-		\WP_Mock::userFunction( 'WPML\Container\share', [
-			'times'  => 1,
-			'args'   => [
-				[
-					'\WPML\PB\Gutenberg\ReusableBlocks\Blocks',
-					'\WPML\PB\Gutenberg\ReusableBlocks\Translation',
-				],
-			],
-		] );
-
 		$this->expect_container_make( 1, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', 'WPML\PB\Gutenberg\Integration' );
 		$this->expect_container_make( (int) $is_admin, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -31,10 +31,8 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
 		\Mockery::mock( 'WPML_PB_String_Translation' );
 
-		\WP_Mock::userFunction( 'WPML\Container\make', [
-			'args'   => [ '\WPML_Translation_Basket' ],
-			'return' => $this->getMockBuilder( '\WPML_Translation_Basket' )->getMock(),
-		] );
+		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', '\WPML\PB\Gutenberg\Integration' );
+		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
 
 		$factory = new WPML_Gutenberg_Integration_Factory();
 
@@ -66,10 +64,18 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
 		\Mockery::mock( 'WPML_PB_String_Translation' );
 
-		\WP_Mock::userFunction( 'WPML\Container\make', [
-			'args'   => [ '\WPML_Translation_Basket' ],
-			'return' => $this->getMockBuilder( '\WPML_Translation_Basket' )->getMock(),
+		\WP_Mock::userFunction( 'WPML\Container\share', [
+			'times'  => 1,
+			'args'   => [
+				[
+					'\WPML\PB\Gutenberg\ReusableBlocks\Blocks',
+					'\WPML\PB\Gutenberg\ReusableBlocks\Translation',
+				],
+			],
 		] );
+
+		$this->expect_container_make( 1, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', 'WPML\PB\Gutenberg\Integration' );
+		$this->expect_container_make( (int) $is_admin, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
 
 		$factory = new WPML_Gutenberg_Integration_Factory();
 
@@ -83,5 +89,19 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 			[ true ],
 			[ false ],
 		];
+	}
+
+	private function expect_container_make( $times, $class, $interface = null ) {
+		if ( $interface ) {
+			$mock = \Mockery::mock( $interface );
+		} else {
+			$mock = \Mockery::mock( $class );
+		}
+
+		\WP_Mock::userFunction( 'WPML\Container\make', [
+			'times'  => $times,
+			'args'   => [ $class ],
+			'return' => $mock,
+		] );
 	}
 }


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6601

The second commit is to address a suggestion made by @brucepearson in https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/pull/37#discussion_r283064217.