### PR TITLE
Add support for nested reusable blocks translation

### DIFF
--- a/src/reusable-blocks/class-blocks.php
+++ b/src/reusable-blocks/class-blocks.php
@@ -16,11 +16,14 @@ class Blocks {
 	}
 
 	/**
+	 * We get block IDs recursively to find possible
+	 * nested reusable blocks.
+	 * 
 	 * @param int $post_id
 	 *
 	 * @return array
 	 */
-	public function getIdsFromPost( $post_id ) {
+	public function getChildrenIdsFromPost( $post_id ) {
 		$post = get_post( $post_id );
 
 		if ( $post ) {
@@ -30,8 +33,9 @@ class Blocks {
 				       && isset( $block['attrs']['ref'] )
 				       && is_numeric( $block['attrs']['ref'] );
 			})->map( function( $block ) {
-				return (int) $block['attrs']['ref'];
-			})->toArray();
+				$block_id = (int) $block['attrs']['ref'];
+				return array_merge( [ $block_id ], $this->getChildrenIdsFromPost( $block_id ) );
+			})->flatten()->toArray();
 		}
 
 		return [];

--- a/src/reusable-blocks/class-manage.php
+++ b/src/reusable-blocks/class-manage.php
@@ -69,7 +69,7 @@ abstract class Manage {
 			return [];
 		}
 
-		return \collect( $this->blocks->getIdsFromPost( $element->get_element_id() ) )
+		return \collect( $this->blocks->getChildrenIdsFromPost( $element->get_element_id() ) )
 			->map( function( $block_id ) use ( $element ) {
 				return (object) [
 					'block_id'      => $block_id,

--- a/tests/phpunit/tests/reusable-blocks/test-manage-basket.php
+++ b/tests/phpunit/tests/reusable-blocks/test-manage-basket.php
@@ -81,7 +81,7 @@ class TestManageBasket extends \OTGS_TestCase {
 		];
 
 		$blocks_mock = $this->getBlocks();
-		$blocks_mock->method( 'getIdsFromPost' )->willReturnMap( $post_to_reusable_blocks );
+		$blocks_mock->method( 'getChildrenIdsFromPost' )->willReturnMap( $post_to_reusable_blocks );
 
 		$convert_block_id = [
 			[ $reusable_block_1, 'fr', $reusable_block_1_fr ],
@@ -152,7 +152,7 @@ class TestManageBasket extends \OTGS_TestCase {
 
 	private function getBlocks() {
 		return $this->getMockBuilder( Blocks::class )
-		            ->setMethods( [ 'getIdsFromPost' ] )
+		            ->setMethods( [ 'getChildrenIdsFromPost' ] )
 		            ->disableOriginalConstructor()->getMock();
 	}
 

--- a/tests/phpunit/tests/reusable-blocks/test-manage-batch.php
+++ b/tests/phpunit/tests/reusable-blocks/test-manage-batch.php
@@ -44,7 +44,7 @@ class TestManageBatch extends \OTGS_TestCase {
 		];
 
 		$blocks_mock = $this->getBlocks();
-		$blocks_mock->method( 'getIdsFromPost' )->willReturnMap( $post_to_reusable_blocks );
+		$blocks_mock->method( 'getChildrenIdsFromPost' )->willReturnMap( $post_to_reusable_blocks );
 
 		$convert_block_id = [
 			[ $reusable_block_1, 'fr', $reusable_block_1_fr ],
@@ -80,7 +80,7 @@ class TestManageBatch extends \OTGS_TestCase {
 
 	private function getBlocks() {
 		return $this->getMockBuilder( Blocks::class )
-			->setMethods( [ 'getIdsFromPost' ] )
+			->setMethods( [ 'getChildrenIdsFromPost' ] )
 			->disableOriginalConstructor()->getMock();
 	}
 


### PR DESCRIPTION
`Blocks::getIdsFromPost` will lookup recursively in blocks.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6598