### PR TITLE
Allow to define a global configuration for a block namespace

### DIFF
--- a/src/strings-in-block/class-attributes.php
+++ b/src/strings-in-block/class-attributes.php
@@ -178,7 +178,7 @@ class Attributes extends Base {
 	 * @return array
 	 */
 	private function getAttributes( \WP_Block_Parser_Block $block ) {
-		return ! empty( $block->attrs ) && is_array( $block->attrs ) ? $block->attrs : [];
+		return is_array( $block->attrs ) && $block->blockName ? $block->attrs : [];
 	}
 
 	/**

--- a/src/strings-in-block/class-base.php
+++ b/src/strings-in-block/class-base.php
@@ -27,9 +27,18 @@ abstract class Base implements StringsInBlock {
 
 		if ( isset( $block->blockName, $this->block_types[ $block->blockName ][ $type ] ) ) {
 			return $this->block_types[ $block->blockName ][ $type ];
-		} else {
-			return null;
 		}
+
+		if ( isset( $block->blockName ) ) {
+			$block_name_arr  = explode( '/', $block->blockName );
+			$block_namespace = reset( $block_name_arr );
+
+			if ( isset( $this->block_types[ $block_namespace ][ $type ] ) ) {
+				return $this->block_types[ $block_namespace ][ $type ];
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/phpunit/tests/test-wpml-gutenberg-string-registration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-string-registration.php
@@ -401,6 +401,8 @@ class Test_WPML_Gutenberg_String_Registration extends OTGS_TestCase {
 		 * @var \WP_Block_Parser_Block|\Mockery\MockInterface $block
 		 */
 		$block = \Mockery::mock( 'WP_Block_Parser_Block' );
+		$block->blockName = null;
+		$block->attrs     = null;
 
 		if ( $name ) {
 			$block->blockName = $name;


### PR DESCRIPTION
If no config is found for the specific block, we'll try to find a
configuration for the block namespace.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6635

I also added a second commit to make sure `blockName` attribute is set. I never got this situation in my tests, but I saw that we have this kind of check for the HMTL strings, so let's have the same verification for Attributes.