### PR TITLE
Prevent loading reusable blocks integration if the basket class is missing (TM is not active)

### DIFF
--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -51,8 +51,10 @@ class WPML_Gutenberg_Integration_Factory {
 		/** @var SitePress $sitepress */
 		global $sitepress;
 
-		return $sitepress->is_translated_post_type(
+		$is_translatable = $sitepress->is_translated_post_type(
 			WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE
 		);
+
+		return class_exists( '\WPML_Translation_Basket' ) && $is_translatable;
 	}
 }

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -50,6 +50,8 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 	public function it_creates_when_reusable_blocks_are_translatable( $is_admin ) {
 		global $sitepress, $wpdb;
 
+		$this->getMockBuilder( '\WPML_Translation_Basket' )->disableOriginalConstructor()->getMock();
+		
 		\WP_Mock::userFunction( 'is_admin', [
 			'return' => $is_admin,
 		] );


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6640