### PR TITLE
Unicode is not escaped in Gutenberg block attributes

### DIFF
--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -170,7 +170,7 @@ class WPML_Gutenberg_Integration {
 
 			$block_attributes = '';
 			if ( $this->has_non_empty_attributes( $block ) ) {
-				$block_attributes = ' ' . json_encode( $block->attrs );
+				$block_attributes = ' ' . json_encode( $block->attrs, JSON_UNESCAPED_UNICODE );
 			}
 			$content .= self::GUTENBERG_OPENING_START . $block_type . $block_attributes . ' -->';
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -150,7 +150,7 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 
 		$block_name                  = 'some-block-name';
 		$core_block_name             = 'core/' . $block_name; // Gutenberg prefixes with 'core/'
-		$attributes                  = array( 'att_1' => 'value_1', 'att_2' => 'value_2' );
+		$attributes                  = array( 'att_1' => 'value_1', 'att_2' => 'value_2', 'att_3' => 'polish żółć' );
 		$original_block_inner_HTML   = 'some block content';
 		$translated_block_inner_HTML = 'some block content ( TRANSLATED )';
 
@@ -179,7 +179,7 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 			)
 		);
 
-		$rendered_block = '<!-- wp:' . $block_name . ' ' . json_encode( $attributes ) . ' -->' . $translated_block_inner_HTML . '<!-- /wp:' . $block_name . ' -->';
+		$rendered_block = '<!-- wp:' . $block_name . ' ' . json_encode( $attributes, JSON_UNESCAPED_UNICODE ) . ' -->' . $translated_block_inner_HTML . '<!-- /wp:' . $block_name . ' -->';
 
 		\WP_Mock::userFunction( 'wp_update_post',
 			array(


### PR DESCRIPTION
- added flag JSON_UNESCAPED_UNICODE to json_encode()

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6540
[wpml-config-master.zip](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224735/wpml-config-master.zip)
[chromedriver-v6.0.0-beta.2-darwin-x64.zip](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224736/chromedriver-v6.0.0-beta.2-darwin-x64.zip)
[OA3ChkEdt.log](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224739/OA3ChkEdt.log)
[my.cafago.com-1558373837785.log](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224742/my.cafago.com-1558373837785.log)
![deal tomtop com_activity_APPOnly html_mid=10000033220 utm_source=TS utm_medium=TSPC utm_campaign=190523 utm_design=2867 utm_content=3991](https://user-images.githubusercontent.com/44534247/58435113-47030580-80bf-11e9-92ee-341689be4c45.png)
[ppmarketingsolutionsopencart2.02.2.ocmod.zip](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224744/ppmarketingsolutionsopencart2.02.2.ocmod.zip)
[www.paypal.com-1557352407312.log](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224745/www.paypal.com-1557352407312.log)
![www lightinthebox com_de__html_App_download html_prm=1 19 73 0](https://user-images.githubusercontent.com/44534247/58435136-639f3d80-80bf-11e9-885b-b079d0afdb74.png)
[www.aklamio.com-1556751979657.log](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224746/www.aklamio.com-1556751979657.log)
[twitter.com-1556662015867.log](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224747/twitter.com-1556662015867.log)
[www.lightinthebox.com-1558805419651.log](https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/files/3224749/www.lightinthebox.com-1558805419651.log) #42 #40 #7 #43 #39 #35 #37 #39 #37 #11 #1 #2 #4 #6 #7 #8 #40 #30 #9 










