### PR TITLE
Correctly set the restricted screen IDs for the reusable block jobs notice

### DIFF
--- a/src/reusable-blocks/class-job-links.php
+++ b/src/reusable-blocks/class-job-links.php
@@ -40,6 +40,6 @@ class JobLinks {
 		                           . $job_id );
 		$job_edit_url = apply_filters( 'icl_job_edit_url', $job_edit_url, $job_id );
 
-		return '<a href="' . $job_edit_url . '" target="_blank">' . $job->title . '</a>';
+		return '<a href="' . $job_edit_url . '" class="wpml-external-link" target="_blank">' . $job->title . '</a>';
 	}
 }

--- a/src/reusable-blocks/class-notice.php
+++ b/src/reusable-blocks/class-notice.php
@@ -32,8 +32,30 @@ class Notice {
 
 		$notice = $this->notices->create_notice( 'automatic-jobs', $text, __CLASS__ );
 		$notice->set_flash( true );
-		$notice->set_restrict_to_screen_ids( [ 'post', 'edit-post' ] );
+		$notice->set_restrict_to_screen_ids( $this->getRestrictScreenIDs() );
 		$notice->set_css_class_types( 'notice-info' );
 		$this->notices->add_notice( $notice );
+	}
+
+	/**
+	 * @return array
+	 */
+	private function getRestrictScreenIDs() {
+		$screen_ids = [ 'post', 'edit-post' ];
+
+		if ( isset( $_GET['return_url'] ) ) {
+			$query  = wpml_parse_url( $_GET['return_url'], PHP_URL_QUERY );
+			parse_str( $query, $params );
+
+			if ( isset( $params['post'] ) ) {
+				$post_id    = filter_var( $params['post'], FILTER_VALIDATE_INT );
+				$screen_ids = [ get_post_type( $post_id ) ];
+			} elseif ( isset( $params['post_type'] ) ) {
+				$post_type  = filter_var( $params['post_type'], FILTER_SANITIZE_STRING );
+				$screen_ids = [ 'edit-' . $post_type ];
+			}
+		}
+
+		return $screen_ids;
 	}
 }

--- a/src/reusable-blocks/class-notice.php
+++ b/src/reusable-blocks/class-notice.php
@@ -33,6 +33,7 @@ class Notice {
 		$notice = $this->notices->create_notice( 'automatic-jobs', $text, __CLASS__ );
 		$notice->set_flash( true );
 		$notice->set_restrict_to_screen_ids( $this->getRestrictScreenIDs() );
+		$notice->set_hideable( true );
 		$notice->set_css_class_types( 'notice-info' );
 		$this->notices->add_notice( $notice );
 	}

--- a/tests/phpunit/tests/reusable-blocks/test-job-links.php
+++ b/tests/phpunit/tests/reusable-blocks/test-job-links.php
@@ -118,6 +118,6 @@ class TestJobLinks extends \OTGS_TestCase {
 	 * @return string
 	 */
 	private function getExpectedJobLink( \stdClass $job ) {
-		return '<a href="' . $this->getEditURLFiltered( $job->job_id ) . '" target="_blank">' . $job->title . '</a>';
+		return '<a href="' . $this->getEditURLFiltered( $job->job_id ) . '" class="wpml-external-link" target="_blank">' . $job->title . '</a>';
 	}
 }

--- a/tests/phpunit/tests/reusable-blocks/test-notice.php
+++ b/tests/phpunit/tests/reusable-blocks/test-notice.php
@@ -103,10 +103,11 @@ class TestNotice extends \OTGS_TestCase {
 	 */
 	private function getExpectedNoticesMock( $expected_text, $restricted_screen_ids ) {
 		$notice = $this->getMockBuilder( '\WPML_Notice' )
-		               ->setMethods( [ 'set_flash', 'set_restrict_to_screen_ids', 'set_css_class_types' ] )
+		               ->setMethods( [ 'set_flash', 'set_restrict_to_screen_ids', 'set_hideable', 'set_css_class_types' ] )
 		               ->disableOriginalConstructor()->getMock();
 		$notice->expects( $this->once() )->method( 'set_flash' )->with( true );
 		$notice->expects( $this->once() )->method( 'set_restrict_to_screen_ids' )->with( $restricted_screen_ids );
+		$notice->expects( $this->once() )->method( 'set_hideable' )->with( true );
 		$notice->expects( $this->once() )->method( 'set_css_class_types' )->with( 'notice-info' );
 
 		$notices = $this->getMockBuilder( '\WPML_Notices' )


### PR DESCRIPTION
I wrongly thought that the screen ID was the same regardless the post
type. We will get the screen ID information from the `return_url`
parameter.

Also added a second commit for polishing (see screenshots below):
- Allow to hide the notice.
- Show the external link icon.

![notice-in-editor](https://user-images.githubusercontent.com/1941656/58709863-72247800-8391-11e9-925a-725cc5e76232.png)

![notice-in-list](https://user-images.githubusercontent.com/1941656/58709868-7486d200-8391-11e9-9603-45052f9a997a.png)

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6652