### PR TITLE
Do not display the notice if we do not have block job links

### DIFF
--- a/src/reusable-blocks/class-notice.php
+++ b/src/reusable-blocks/class-notice.php
@@ -21,6 +21,10 @@ class Notice {
 	public function addJobsCreatedAutomatically( array $job_ids ) {
 		$job_links = $this->job_links->get( $job_ids );
 
+		if ( $job_links->isEmpty() ) {
+			return;
+		}
+
 		$text = '<p>' . _n(
 			'We automatically created a translation job for the reusable block:',
 			'We automatically created translation jobs for the reusable blocks:',

--- a/tests/phpunit/tests/reusable-blocks/test-notice.php
+++ b/tests/phpunit/tests/reusable-blocks/test-notice.php
@@ -9,7 +9,25 @@ class TestNotice extends \OTGS_TestCase {
 
 	const POST_ID   = 123;
 	const POST_TYPE = 'page';
-	
+
+	/**
+	 * @test
+	 * @group wpmlcore-6659
+	 */
+	public function it_should_not_add_a_notice_if_no_block_job_links() {
+		$job_ids               = [ '123' ];
+		$empty_link_collection = collect( [] );
+		$job_links             = $this->getJobLinksMock( $job_ids, $empty_link_collection );
+
+		$notices = $this->getMockBuilder( '\WPML_Notices' )
+			->setMethods( [ 'add_notice' ] )->disableOriginalConstructor()->getMock();
+		$notices->expects( $this->never() )->method( 'add_notice' );
+
+		$subject = $this->getSubject( $notices, $job_links );
+
+		$subject->addJobsCreatedAutomatically( $job_ids );
+	}
+
 	/**
 	 * @test
 	 * @dataProvider dp_add_notice_with_reusable_blocks_job_links


### PR DESCRIPTION
I had this check at the beginning and I probably lost it after some
refactoring
https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/pull/46#discussion_r288362732

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6659