### PR TITLE
Return an empty array when a block has an empty config

### DIFF
--- a/src/strings-in-block/class-base.php
+++ b/src/strings-in-block/class-base.php
@@ -29,6 +29,26 @@ abstract class Base implements StringsInBlock {
 			return $this->block_types[ $block->blockName ][ $type ];
 		}
 
+		$namespace_config = $this->get_namespace_config( $block, $type );
+
+		if ( $namespace_config ) {
+			return $namespace_config;
+		}
+
+		if ( $this->has_empty_config( $block ) ) {
+			return [];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param \WP_Block_Parser_Block $block
+	 * @param string                 $type
+	 *
+	 * @return array|null
+	 */
+	public function get_namespace_config( \WP_Block_Parser_Block $block, $type ) {
 		if ( isset( $block->blockName ) ) {
 			$block_name_arr  = explode( '/', $block->blockName );
 			$block_namespace = reset( $block_name_arr );
@@ -39,6 +59,15 @@ abstract class Base implements StringsInBlock {
 		}
 
 		return null;
+	}
+
+	/**
+	 * @param \WP_Block_Parser_Block $block
+	 *
+	 * @return bool
+	 */
+	private function has_empty_config( \WP_Block_Parser_Block $block ) {
+		return isset( $block->blockName, $this->block_types[ $block->blockName ] );
 	}
 
 	/**

--- a/tests/phpunit/tests/strings-in-block/test-html.php
+++ b/tests/phpunit/tests/strings-in-block/test-html.php
@@ -58,12 +58,13 @@ class TestHTML extends \OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6661
 	 */
-	public function it_does_not_find_column_if_there_is_no_xpath() {
+	public function it_does_not_find_the_column_content_if_the_block_configuration_has_no_xpath() {
 
 		$config_option = \Mockery::mock( 'WPML_Gutenberg_Config_Option' );
 		$config_option->shouldReceive( 'get' )
-		              ->andReturn( array( 'core/column' => array( 'xpath' => array() ) ) );
+		              ->andReturn( array( 'core/column' => array() ) );
 
 		$strings_in_block = new HTML( $config_option );
 


### PR DESCRIPTION
It means that the block has nothing to translate. Instead, when we
return `null` for the HTML parsing, it means that the block has no
config and we will register the whole HTML of the block as a string.

We had a unit test on this and I mistakenly updated it while I refactored the code (now this test is clearer to me).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6661