### PR TITLE
Add proper support to nested lists

### DIFF
--- a/src/strings-in-block/class-attributes.php
+++ b/src/strings-in-block/class-attributes.php
@@ -46,7 +46,7 @@ class Attributes extends Base {
 					$this->findStringsRecursively( $attr_value, $children_config_keys, $block_name )
 				);
 			} elseif ( ! is_numeric( $attr_value ) ) {
-				$type      = $this->get_string_type( $attr_value );
+				$type      = self::get_string_type( $attr_value );
 				$string_id = $this->get_string_id( $block_name, $attr_value );
 				$strings[] = $this->build_string( $string_id, $block_name, $attr_value, $type );
 			}

--- a/src/strings-in-block/class-base.php
+++ b/src/strings-in-block/class-base.php
@@ -46,7 +46,7 @@ abstract class Base implements StringsInBlock {
 	 *
 	 * @return string
 	 */
-	protected function get_string_type( $string ) {
+	public static function get_string_type( $string ) {
 		$type = 'LINE';
 
 		if ( strpos( $string, "\n" ) !== false ) {

--- a/src/strings-in-block/dom-handler/dom-handle.php
+++ b/src/strings-in-block/dom-handler/dom-handle.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace WPML\PB\Gutenberg\StringsInBlock\DOMHandler;
+
+use WPML\PB\Gutenberg\StringsInBlock\Base;
+
+abstract class DOMHandle {
+
+	const INNER_HTML_PARTIAL = 'partial';
+	const INNER_HTML_FULL    = 'full';
+
+	/**
+	 * @param string $html
+	 *
+	 * @return \DOMXPath
+	 */
+	public function getDomxpath( $html ) {
+		$dom = $this->getDom( $html );
+
+		return new \DOMXPath( $dom );
+	}
+
+	/**
+	 * @param string $html
+	 *
+	 * @return \DOMDocument
+	 */
+	public function getDom( $html ) {
+		$dom = new \DOMDocument();
+		\libxml_use_internal_errors( true );
+		$html = mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' );
+		$dom->loadHTML( '<div>' . $html . '</div>' );
+		\libxml_clear_errors();
+
+		// Remove doc type and <html> <body> wrappers
+		$dom->removeChild( $dom->doctype );
+		$dom->replaceChild( $dom->firstChild->firstChild->firstChild, $dom->firstChild );
+
+		return $dom;
+	}
+
+	/**
+	 * @param \DOMNode $element
+	 * @param string   $context
+	 *
+	 * @return array
+	 */
+	private function getInnerHTML( \DOMNode $element, $context ) {
+		$innerHTML = $this->getInnerHTMLFromChildNodes( $element, $context );
+
+		$type = Base::get_string_type( $innerHTML );
+
+		if ( 'VISUAL' !== $type ) {
+			$innerHTML = html_entity_decode( $innerHTML );
+		}
+
+		return array( $innerHTML, $type );
+	}
+
+	/**
+	 * @param \DOMNode $element
+	 * @param string   $context
+	 *
+	 * @return string
+	 */
+	abstract protected function getInnerHTMLFromChildNodes( \DOMNode $element, $context );
+
+	/**
+	 * @param \DOMNode $element
+	 *
+	 * @return array
+	 */
+	public function getPartialInnerHTML( \DOMNode $element ) {
+		return $this->getInnerHTML( $element, self::INNER_HTML_PARTIAL );
+	}
+
+	/**
+	 * @param \DOMNode $element
+	 *
+	 * @return array
+	 */
+	public function getFullInnerHTML( \DOMNode $element ) {
+		return $this->getInnerHTML( $element, self::INNER_HTML_FULL );
+	}
+
+	/**
+	 * @param \DOMNode $element
+	 * @param string   $value
+	 */
+	public function setElementValue( \DOMNode $element, $value ) {
+		if ( $element instanceof \DOMAttr ) {
+			$element->parentNode->setAttribute( $element->name, $value );
+		} else {
+			$clone = $this->cloneNodeWithoutChildren( $element );
+			$fragment = $this->getDom( $value )->firstChild; // Skip the wrapping div
+			foreach ( $fragment->childNodes as $child ) {
+				$clone->appendChild( $element->ownerDocument->importNode( $child, true ) );
+			}
+
+			$this->appendExtraChildNodes( $clone, $element );
+
+			$element->parentNode->replaceChild( $clone, $element );
+		}
+	}
+
+	/**
+	 * @param \DOMNode $clone
+	 * @param \DOMNode $element
+	 */
+	abstract protected function appendExtraChildNodes( \DOMNode $clone, \DOMNode $element );
+
+	/**
+	 * @param \DOMNode $element
+	 *
+	 * @return \DOMNode
+	 */
+	private function cloneNodeWithoutChildren( \DOMNode $element ) {
+		return $element->cloneNode( false );
+	}
+}

--- a/src/strings-in-block/dom-handler/list-block.php
+++ b/src/strings-in-block/dom-handler/list-block.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace WPML\PB\Gutenberg\StringsInBlock\DOMHandler;
+
+class ListBlock extends DOMHandle {
+
+	/**
+	 * @param \DOMNode $element
+	 * @param string   $context
+	 *
+	 * @return string
+	 */
+	protected function getInnerHTMLFromChildNodes( \DOMNode $element, $context ) {
+		$innerHTML  = "";
+		$is_partial = self::INNER_HTML_PARTIAL === $context;
+		$children   = $element->childNodes;
+
+		foreach ( $children as $child ) {
+			if ( $is_partial && $this->isListNode( $child ) ) {
+				continue;
+			}
+
+			$innerHTML .= $element->ownerDocument->saveHTML( $child );
+		}
+
+		if ( $is_partial ) {
+			$innerHTML = trim( $innerHTML );
+		}
+
+		return $innerHTML;
+	}
+
+	/**
+	 * @param \DOMNode $clone
+	 * @param \DOMNode $element
+	 */
+	protected function appendExtraChildNodes( \DOMNode $clone, \DOMNode $element ) {
+		$child_list = $this->getChildList( $element );
+
+		if ( $child_list ) {
+			$clone->appendChild( $child_list );
+		}
+	}
+
+	/**
+	 * @param \DOMNode $node
+	 *
+	 * @return \DOMNode|null
+	 */
+	private function getChildList( \DOMNode $node ) {
+		foreach ( $node->childNodes as $child_node ) {
+			if ( $this->isListNode( $child_node ) ) {
+				return $child_node;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param \DOMNode $node
+	 *
+	 * @return bool
+	 */
+	private function isListNode( \DOMNode $node ) {
+		return isset( $node->tagName ) && in_array( $node->tagName, [ 'ul', 'ol' ], true );
+	}
+}

--- a/src/strings-in-block/dom-handler/standard-block.php
+++ b/src/strings-in-block/dom-handler/standard-block.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WPML\PB\Gutenberg\StringsInBlock\DOMHandler;
+
+class StandardBlock extends DOMHandle {
+
+	/**
+	 * @param \DOMNode $element
+	 * @param string   $context
+	 *
+	 * @return string
+	 */
+	protected function getInnerHTMLFromChildNodes( \DOMNode $element, $context ) {
+		$innerHTML = "";
+		$children  = $element->childNodes;
+
+		foreach ( $children as $child ) {
+			$innerHTML .= $element->ownerDocument->saveHTML( $child );
+		}
+
+		return $innerHTML;
+	}
+
+	/**
+	 * @param \DOMNode $clone
+	 * @param \DOMNode $element
+	 */
+	protected function appendExtraChildNodes( \DOMNode $clone, \DOMNode $element ) {
+
+	}
+}


### PR DESCRIPTION
The HTML lists are specific elements which requires a dedicated handling
when we register the strings or translate the block.

Summary of the changes:
1. At registration, we will exclude the nested list from the value. However, the registered string can still be composed of HTML tags.
2. When we update the block, we will also append the list child element if there's one in the original. The child element will be updated on its own.

Here's an example of nested list:

```html
<ul>
    <li>Parent <strong>1</strong>
        <ol>
            <li>Child <strong>1</strong>
                <ul>
                    <li>Grandchild 11</li>
                    <li>Grandchild 12</li>
                </ul>
            </li>
        </ol>
    </li>
    <li>Parent 2
        <ul>
            <li>Child 2</li>
        </ul>
    </li>
</ul>
```

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6613

This also requires a small change in the config file https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/merge_requests/2400.