### PR TITLE
Remove type hints for `\Illuminate\Support\Collection`

### DIFF
--- a/src/reusable-blocks/class-job-links.php
+++ b/src/reusable-blocks/class-job-links.php
@@ -14,7 +14,7 @@ class JobLinks {
 	/**
 	 * @param array $job_ids
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection
 	 */
 	public function get( array $job_ids ) {
 		return \collect( $job_ids )->map( function( $job_id ) {

--- a/src/reusable-blocks/class-manage-basket.php
+++ b/src/reusable-blocks/class-manage-basket.php
@@ -50,7 +50,7 @@ class ManageBasket extends Manage {
 	/**
 	 * @param array $data
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection
 	 */
 	private function extractAddedPostElements( array $data ) {
 		$source_lang  = $data['translate_from'];

--- a/src/reusable-blocks/class-manage.php
+++ b/src/reusable-blocks/class-manage.php
@@ -19,7 +19,7 @@ abstract class Manage {
 	}
 
 	/**
-	 * @param \Illuminate\Support\Collection $blocks
+	 * @param \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection $blocks
 	 *
 	 * [
 	 *  (object) [
@@ -34,7 +34,7 @@ abstract class Manage {
 	 *  ],
 	 * ]
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection
 	 */
 	protected function getBlockElementsToAdd( $blocks ) {
 		return $blocks->map( [ $this, 'selectTargetLangs' ] )
@@ -42,11 +42,11 @@ abstract class Manage {
 	}
 
 	/**
-	 * @param \Illuminate\Support\Collection $post_elements
+	 * @param \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection $post_elements
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection
 	 */
-	protected function getBlocksFromPostElements( \Illuminate\Support\Collection $post_elements ) {
+	protected function getBlocksFromPostElements( $post_elements ) {
 		return $post_elements->map( [ $this, 'findBlocksInElement' ] )
 		                     ->flatten( 1 )
 		                     ->unique( 'block_id' );

--- a/tests/phpunit/tests/reusable-blocks/test-notice.php
+++ b/tests/phpunit/tests/reusable-blocks/test-notice.php
@@ -140,12 +140,12 @@ class TestNotice extends \OTGS_TestCase {
 	}
 
 	/**
-	 * @param array                          $job_ids
-	 * @param \Illuminate\Support\Collection $links
+	 * @param array                                                                $job_ids
+	 * @param \Tightenco\Collect\Support\Collection|\Illuminate\Support\Collection $links
 	 *
 	 * @return \PHPUnit_Framework_MockObject_MockObject|JobLinks
 	 */
-	private function getJobLinksMock( array $job_ids, \Illuminate\Support\Collection $links ) {
+	private function getJobLinksMock( array $job_ids, $links ) {
 		$job_links = $this->getMockBuilder( JobLinks::class )
 			->setMethods( [ 'get' ] )
 			->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
This will prevent fatal errors if a new version of
`tightenco/collect` is already loaded.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6677