### PR TITLE
Prevent adding reusable blocks to the basket if the parent post has the same source lang as the target lang

### DIFF
--- a/src/reusable-blocks/class-translation.php
+++ b/src/reusable-blocks/class-translation.php
@@ -39,4 +39,15 @@ class Translation {
 	public function convertBlockId( $block_id, $lang = null ) {
 		return $this->sitepress->get_object_id( $block_id, self::POST_TYPE, true, $lang );
 	}
+
+	/**
+	 * @param int $post_id
+	 *
+	 * @return string|null
+	 */
+	public function getSourceLang( $post_id ) {
+		$details = $this->sitepress->get_element_language_details( $post_id, 'post_' . get_post_type( $post_id ) );
+
+		return isset( $details->source_language_code ) ? $details->source_language_code : null;
+	}
 }

--- a/tests/phpunit/tests/reusable-blocks/test-manage-basket.php
+++ b/tests/phpunit/tests/reusable-blocks/test-manage-basket.php
@@ -133,6 +133,47 @@ class TestManageBasket extends \OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6689
+	 */
+	public function it_should_NOT_add_block_for_a_post_translated_to_its_source_language() {
+		$source_lang               = 'en';
+		$fr                        = 'fr';
+		$de                        = 'de';
+		$post_with_reusable_blocks = 123;
+
+		$data = [
+			'translate_from' => $source_lang,
+			'post'           => [
+				$post_with_reusable_blocks => [
+					'type'    => 'post',
+					'checked' => $post_with_reusable_blocks,
+				],
+			],
+			'tr_action'      => [
+				$fr => '1',
+				$de => '0',
+			],
+		];
+
+		$blocks_mock = $this->getBlocks();
+		$blocks_mock->expects( $this->never() )
+		            ->method( 'getChildrenIdsFromPost' );
+
+		$translation_mock = $this->getTranslation();
+		$translation_mock->method( 'getSourceLang' )
+			->with( $post_with_reusable_blocks )->willReturn( $fr );
+
+		$basket_mock = $this->getTranslationBasket();
+		$basket_mock->expects( $this->never() )
+		            ->method( 'update_basket' );
+
+		$subject = $this->getSubject( $blocks_mock, $translation_mock, $basket_mock );
+
+		$subject->addBlocks( $data );
+	}
+
+	/**
+	 * @test
 	 * @group wpmlcore-6590
 	 * @expectedException \RuntimeException
 	 */
@@ -158,7 +199,7 @@ class TestManageBasket extends \OTGS_TestCase {
 
 	private function getTranslation() {
 		return $this->getMockBuilder( Translation::class )
-		            ->setMethods( [ 'convertBlockId' ] )
+		            ->setMethods( [ 'convertBlockId', 'getSourceLang' ] )
 		            ->disableOriginalConstructor()->getMock();
 	}
 

--- a/tests/phpunit/tests/reusable-blocks/test-translation.php
+++ b/tests/phpunit/tests/reusable-blocks/test-translation.php
@@ -89,6 +89,39 @@ class TestTranslation extends \OTGS_TestCase {
 			$subject->convertBlock( $block, $lang )
 		);
 	}
+
+	/**
+	 * @test
+	 * @dataProvider dp_post_details
+	 * @group wpmlcore-6689
+	 *
+	 * @param null|\stdClass $post_details
+	 * @param null|string    $expected_lang
+	 */
+	public function it_should_get_source_lang_from_post_id( $post_details, $expected_lang ) {
+		$post_id   = 123;
+		$post_type = 'page';
+
+		\WP_Mock::userFunction( 'get_post_type', [
+			'args'   => [ $post_id ],
+			'return' => $post_type,
+		] );
+
+		$sitepress = $this->getSitepress();
+		$sitepress->method( 'get_element_language_details' )
+			->with( $post_id, 'post_' . $post_type )->willReturn( $post_details );
+
+		$subject = $this->getSubject( $sitepress );
+
+		$this->assertEquals( $expected_lang, $subject->getSourceLang( $post_id ) );
+	}
+	
+	public function dp_post_details() {
+		return [
+			[ (object) [ 'source_language_code' => 'fr' ], 'fr' ],
+			[ false, null ],
+		];
+	}
 	
 	private function getSubject( $sitepress = null ) {
 		$sitepress = $sitepress ? $sitepress : $this->getSitepress();
@@ -97,7 +130,7 @@ class TestTranslation extends \OTGS_TestCase {
 
 	private function getSitepress() {
 		return $this->getMockBuilder( \SitePress::class )
-			->setMethods( [ 'set_element_language_details', 'get_object_id' ] )
+			->setMethods( [ 'get_element_language_details', 'get_object_id' ] )
 			->disableOriginalConstructor()->getMock();
 	}
 }


### PR DESCRIPTION
We will filter the target langs before to scan the post looking for
reusable blocks.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6689