### PR TITLE
Do not load reusable block integration if TM is not loaded

### DIFF
--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -63,6 +63,8 @@ class WPML_Gutenberg_Integration_Factory {
 		);
 
 		// We need to make sure that the DIC is used on TM
-		return class_exists( '\WPML\TM\Container\Config' ) && $is_translatable;
+		return class_exists( '\WPML\TM\Container\Config' )
+		       && did_action( 'wpml_after_tm_loaded' )
+		       && $is_translatable;
 	}
 }

--- a/tests/phpunit/tests/reusable-blocks/test-admin-integration.php
+++ b/tests/phpunit/tests/reusable-blocks/test-admin-integration.php
@@ -11,6 +11,8 @@ class TestAdminIntegration extends \OTGS_TestCase {
 	 * @test
 	 */
 	public function it_should_add_hooks() {
+		$this->getMockBuilder( '\WPML_TM_Translation_Batch' )->getMock();
+
 		$subject = $this->getSubject();
 
 		\WP_Mock::expectFilterAdded( 'wpml_send_jobs_batch', [ $subject, 'addBlocksToBatch' ] );
@@ -22,9 +24,13 @@ class TestAdminIntegration extends \OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @runInSeparateProcess
+	 * @preserveGlobalState false
 	 */
 	public function it_should_add_hooks_when_submitting_the_basket() {
 		$_POST = [ 'action' => 'send_basket_item' ];
+
+		$this->getMockBuilder( '\WPML_TM_Translation_Batch' )->getMock();
 
 		$subject = $this->getSubject();
 

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -34,6 +34,11 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'WPML_PB_String_Translation' );
 		\Mockery::mock( '\WPML\TM\Container\Config' );
 
+		\WP_Mock::userFunction( 'did_action', [
+			'args'   => [ 'wpml_after_tm_loaded' ],
+			'return' => true,
+		] );
+
 		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', '\WPML\PB\Gutenberg\Integration' );
 		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
 
@@ -68,6 +73,51 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'WPML_ST_String_Factory' );
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
 		\Mockery::mock( 'WPML_PB_String_Translation' );
+
+		\WP_Mock::userFunction( 'did_action', [
+			'args'   => [ 'wpml_after_tm_loaded' ],
+			'return' => true,
+		] );
+
+		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', '\WPML\PB\Gutenberg\Integration' );
+		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
+
+		$factory = new WPML_Gutenberg_Integration_Factory();
+
+		$this->assertInstanceOf( \WPML\PB\Gutenberg\Integration::class, $factory->create() );
+
+		unset( $sitepress );
+	}
+
+	/**
+	 * @test
+	 * @group wpmltm-3548
+	 * @dataProvider dp_is_admin
+	 *
+	 * @param bool $is_admin
+	 */
+	public function it_creates_when_blocks_are_translatable_and_tm_is_not_loaded( $is_admin ) {
+		global $sitepress, $wpdb;
+
+		\WP_Mock::userFunction( 'is_admin', [
+			'return' => $is_admin,
+		] );
+
+		$sitepress = \Mockery::mock( 'SitePress' );
+		$sitepress->shouldReceive( 'is_translated_post_type' )
+		          ->with( WPML\PB\Gutenberg\ReusableBlocks\Translation::POST_TYPE )
+		          ->andReturn( true );
+
+		$wpdb      = \Mockery::mock( 'wpdb' );
+		\Mockery::mock( 'WPML_ST_String_Factory' );
+		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
+		\Mockery::mock( 'WPML_PB_String_Translation' );
+		\Mockery::mock( '\WPML\TM\Container\Config' );
+
+		\WP_Mock::userFunction( 'did_action', [
+			'args'   => [ 'wpml_after_tm_loaded' ],
+			'return' => false,
+		] );
 
 		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', '\WPML\PB\Gutenberg\Integration' );
 		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
@@ -104,6 +154,11 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'WPML_PB_Reuse_Translations' );
 		\Mockery::mock( 'WPML\PB\Gutenberg\StringsInBlock\StringsInBlock' );
 		\Mockery::mock( '\WPML\TM\Container\Config' );
+
+		\WP_Mock::userFunction( 'did_action', [
+			'args'   => [ 'wpml_after_tm_loaded' ],
+			'return' => true,
+		] );
 
 		$this->expect_container_make( 1, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', 'WPML\PB\Gutenberg\Integration' );
 		$this->expect_container_make( (int) $is_admin, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );


### PR DESCRIPTION
FTR, `wpml_after_tm_loaded` action is triggered at the end of `wpml_tm_load` (if we didn't exit the function before: dependency check failed or Core not setup).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltm-3548