### PR TITLE
Introduce classes to convert Ids in block

### DIFF
--- a/src/IdsInBlock/Base.php
+++ b/src/IdsInBlock/Base.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+class Base {
+
+	/**
+	 * @param array $block
+	 *
+	 * @return array
+	 */
+	public function convert( array $block ) {
+		return $block;
+	}
+
+	/**
+	 * @param array|int $ids
+	 * @param string    $elementType
+	 *
+	 * @return array|int
+	 */
+	public static function convertIds( $ids, $elementType ) {
+		$getTranslation = function( $id ) use ( $elementType ) {
+			return (int) wpml_object_id_filter( $id, $elementType );
+		};
+
+		if ( is_array( $ids ) ) {
+			return wpml_collect( $ids )->map( $getTranslation )->toArray();
+		}
+
+		return $getTranslation( $ids );
+	}
+}

--- a/src/IdsInBlock/BlockAttributes.php
+++ b/src/IdsInBlock/BlockAttributes.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+class BlockAttributes extends Base {
+
+	private $attributesToConvert;
+
+	public function __construct( array $attributesToConvert ) {
+		$this->attributesToConvert = $attributesToConvert;
+	}
+
+	public function convert( array $block ) {
+		foreach ( $this->attributesToConvert as $attributeConfig ) {
+			$name = $attributeConfig['name'];
+
+			if ( isset( $block['attrs'][ $name ] ) ) {
+				$block['attrs'][ $name ] = self::convertIds(
+					$block['attrs'][ $name ],
+					$attributeConfig['type']
+				);
+			}
+		}
+
+		return $block;
+	}
+}

--- a/src/IdsInBlock/Composite.php
+++ b/src/IdsInBlock/Composite.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+class Composite extends Base {
+
+	/** @var Base[] $converters */
+	private $converters;
+
+	public function __construct( array $converters ) {
+		$this->converters = $converters;
+	}
+
+	public function convert( array $block ) {
+		foreach ( $this->converters as $converter ) {
+			$block = $converter->convert( $block );
+		}
+
+		return $block;
+	}
+}

--- a/src/IdsInBlock/TagAttributes.php
+++ b/src/IdsInBlock/TagAttributes.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+use WPML\PB\Gutenberg\StringsInBlock\DOMHandler\StandardBlock;
+use WPML\PB\Gutenberg\StringsInBlock\HTML;
+
+class TagAttributes extends Base {
+
+	private $attributesToConvert;
+
+	public function __construct( array $attributesToConvert ) {
+		$this->attributesToConvert = $attributesToConvert;
+	}
+
+	public function convert( array $block ) {
+		$domHandler = new StandardBlock();
+		$dom        = $domHandler->getDom( $block['innerHTML'] );
+		$xpath      = new \DOMXPath( $dom );
+
+		foreach ( $this->attributesToConvert as $attributeConfig ) {
+			$nodes = $xpath->query( $attributeConfig['xpath'] );
+
+			if ( ! $nodes ) {
+				continue;
+			}
+
+			foreach ( $nodes as $node ) {
+				/** @var \DOMNode $node */
+				$ids = implode( ',' , self::convertIds( explode( ',', $node->nodeValue ), $attributeConfig['type'] ) );
+				$blockObject = \WPML_Gutenberg_Integration::sanitize_block( $block );
+				$block = (array) HTML::update_string_in_innerContent( $blockObject, $node, $ids );
+				$domHandler->setElementValue( $node, $ids );
+			}
+		}
+
+		list( $block['innerHTML'], ) = $domHandler->getFullInnerHTML( $dom->documentElement );
+
+		return $block;
+	}
+}

--- a/src/strings-in-block/class-html.php
+++ b/src/strings-in-block/class-html.php
@@ -75,7 +75,7 @@ class HTML extends Base {
 						ICL_TM_COMPLETE == $string_translations[ $string_id ][ $lang ]['status']
 					) {
 						$translation = $string_translations[ $string_id ][ $lang ]['value'];
-						$block       = $this->update_string_in_innerContent( $block, $element, $translation );
+						$block       = self::update_string_in_innerContent( $block, $element, $translation );
 						$dom_handle->setElementValue( $element, $translation );
 					}
 				}
@@ -118,7 +118,7 @@ class HTML extends Base {
 	 *
 	 * @return \WP_Block_Parser_Block
 	 */
-	private function update_string_in_innerContent( \WP_Block_Parser_Block $block, \DOMNode $element, $translation ) {
+	public static function update_string_in_innerContent( \WP_Block_Parser_Block $block, \DOMNode $element, $translation ) {
 		if ( empty( $block->innerContent ) ) {
 			return $block;
 		}
@@ -133,7 +133,7 @@ class HTML extends Base {
 
 		foreach ( $block->innerContent as &$inner_content ) {
 			if ( $inner_content ) {
-				$inner_content = preg_replace( $search, '$1' . $translation . '$3', $inner_content );
+				$inner_content = preg_replace( $search, '${1}' . $translation . '${3}', $inner_content );
 			}
 		}
 

--- a/src/strings-in-block/dom-handler/dom-handle.php
+++ b/src/strings-in-block/dom-handler/dom-handle.php
@@ -29,12 +29,8 @@ abstract class DOMHandle {
 		$dom = new \DOMDocument();
 		\libxml_use_internal_errors( true );
 		$html = mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' );
-		$dom->loadHTML( '<div>' . $html . '</div>' );
+		$dom->loadHTML( '<div>' . $html . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		\libxml_clear_errors();
-
-		// Remove doc type and <html> <body> wrappers
-		$dom->removeChild( $dom->doctype );
-		$dom->replaceChild( $dom->firstChild->firstChild->firstChild, $dom->firstChild );
 
 		return $dom;
 	}

--- a/src/strings-in-block/dom-handler/dom-handle.php
+++ b/src/strings-in-block/dom-handler/dom-handle.php
@@ -121,7 +121,8 @@ abstract class DOMHandle {
 	}
 
 	protected function getAsHTML5( \DOMNode $element ) {
-		return strtr( $element->ownerDocument->saveXML( $element, LIBXML_NOEMPTYTAG ),
+		return strtr(
+			$element->ownerDocument->saveXML( $element, LIBXML_NOEMPTYTAG ),
 			[
 				'></area>'   => '/>',
 				'></base>'   => '/>',

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -39,3 +39,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';
+require_once __DIR__ . '/stubs/wp-block-parser-block.php';

--- a/tests/phpunit/stubs/wp-block-parser-block.php
+++ b/tests/phpunit/stubs/wp-block-parser-block.php
@@ -1,0 +1,17 @@
+<?php
+
+class WP_Block_Parser_Block {
+	public $blockName;
+	public $attrs;
+	public $innerBlocks;
+	public $innerHTML;
+	public $innerContent;
+
+	function __construct( $name, $attrs, $innerBlocks, $innerHTML, $innerContent ) {
+		$this->blockName    = $name;
+		$this->attrs        = $attrs;
+		$this->innerBlocks  = $innerBlocks;
+		$this->innerHTML    = $innerHTML;
+		$this->innerContent = $innerContent;
+	}
+}

--- a/tests/phpunit/tests/IdsInBlock/TestBase.php
+++ b/tests/phpunit/tests/IdsInBlock/TestBase.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+/**
+ * @group convert-ids-in-block
+ */
+class TestBase extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvertAndNotAlterBlock() {
+		$block = [ 'the-block' ];
+
+		$subject = new Base();
+
+		$this->assertEquals( $block, $subject->convert( $block ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvertOneId() {
+		$originalId  = 123;
+		$convertedId = 456;
+		$type        = 'page';
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $originalId, $type ],
+			'return' => $convertedId,
+		] );
+
+		$this->assertSame( $convertedId, Base::convertIds( $originalId, $type ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvertMultipleIds() {
+		$originalId1  = 123;
+		$convertedId1 = 456;
+		$originalId2  = 1000;
+		$convertedId2 = 1001;
+		$type        = 'page';
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $originalId1, $type ],
+			'return' => $convertedId1,
+		] );
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $originalId2, $type ],
+			'return' => $convertedId2,
+		] );
+
+		$this->assertSame(
+			[ $convertedId1, $convertedId2 ],
+			Base::convertIds( [ $originalId1, $originalId2 ], $type )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvertOneIdAndReturnZeroInsteadOfNull() {
+		$originalId  = 123;
+		$type        = 'page';
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $originalId, $type ],
+			'return' => null,
+		] );
+
+		$this->assertSame( 0, Base::convertIds( $originalId, $type ) );
+	}
+}

--- a/tests/phpunit/tests/IdsInBlock/TestBlockAttributes.php
+++ b/tests/phpunit/tests/IdsInBlock/TestBlockAttributes.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+/**
+ * @group convert-ids-in-block
+ */
+class TestBlockAttributes extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvert() {
+		$name        = 'foo';
+		$id          = 123;
+		$convertedId = 456;
+		$type        = 'page';
+
+		$config = [
+			[ 'name' => $name, 'type' => $type ],
+		];
+
+		$getBlock = function( $id ) use ( $name ) {
+			return [
+				'attrs' => [
+					$name       => $id,
+					'something' => 'else',
+				],
+			];
+		};
+
+		$block         = $getBlock( $id );
+		$expectedBlock = $getBlock( $convertedId );
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $id, $type ],
+			'return' => $convertedId,
+		] );
+
+		\Mockery::mock( 'WP_Block_Parser_Block' );
+
+		$subject = new BlockAttributes( $config );
+
+		$this->assertEquals( $expectedBlock, $subject->convert( $block ) );
+	}
+}

--- a/tests/phpunit/tests/IdsInBlock/TestComposite.php
+++ b/tests/phpunit/tests/IdsInBlock/TestComposite.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+/**
+ * @group convert-ids-in-block
+ */
+class TestComposite extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvert() {
+		$initialBlock = [ 'initial-block' ];
+		$blockAfterA  = [ 'block-after-A' ];
+		$finalBlock   = [ 'final-block' ];
+
+		$converters = [
+			$this->getConverter( $initialBlock, $blockAfterA ),
+			$this->getConverter( $blockAfterA, $finalBlock ),
+		];
+
+		$subject = new Composite( $converters );
+
+		$this->assertEquals(
+			$finalBlock,
+			$subject->convert( $initialBlock )
+		);
+	}
+
+	private function getConverter( array $blockIn, array $blockOut ) {
+		$converter = $this->getMockBuilder( Base::class )
+		     ->setMethods( [ 'convert' ] )
+		     ->disableOriginalConstructor()->getMock();
+		$converter->method( 'convert' )->with( $blockIn )->willReturn( $blockOut );
+
+		return $converter;
+	}
+}

--- a/tests/phpunit/tests/IdsInBlock/TestTagAttributes.php
+++ b/tests/phpunit/tests/IdsInBlock/TestTagAttributes.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
+
+/**
+ * @group convert-ids-in-block
+ */
+class TestTagAttributes extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function itShouldConvert() {
+		$id          = 123;
+		$convertedId = 456;
+		$class = 'my-class';
+		$attribute = 'data-my-id';
+		$type = 'page';
+
+		$config = [
+			[ 'xpath' => '//*[contains(@class, "' . $class . '")]/@' . $attribute, 'type' => $type ],
+		];
+
+		$getBlock = function( $id ) use ( $class, $attribute ) {
+			$html = '<div class="something ' . $class . '" ' . $attribute . '="' . $id . '"></div>';
+
+			return [
+				'blockName'    => 'some-name',
+				'attrs'        => [],
+				'innerBlocks'  => [],
+				'innerHTML'    => $html,
+				'innerContent' => [ $html ],
+			];
+		};
+
+		$block         = $getBlock( $id );
+		$expectedBlock = $getBlock( $convertedId );
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $id, $type ],
+			'return' => $convertedId,
+		] );
+
+		$subject = new TagAttributes( $config );
+
+		$this->assertEquals( $expectedBlock, $subject->convert( $block ) );
+	}
+}


### PR DESCRIPTION
**Is required for https://git.onthegosystems.com/wpml/woocommerce-multilingual/merge_requests/1179**

- `BlockAttributes`
- `TagAttributes`
- `NullConverter` (do nothing)
- `Composite` (to composer converters)

This is required to convert blocks in WooCommerce but it can also be
used by other plugins.

https://onthegosystems.myjetbrains.com/youtrack/issue/wcml-2676