### PR TITLE
Improve render_block method for self-closing blocks

### DIFF
--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -154,17 +154,20 @@ class WPML_Gutenberg_Integration implements \WPML\PB\Gutenberg\Integration {
 		$block = self::sanitize_block( $block );
 
 		if ( self::CLASSIC_BLOCK_NAME !== $block->blockName ) {
-			$block_type = preg_replace( '/^core\//', '', $block->blockName );
+			$block_content = self::render_inner_HTML( $block );
+			$block_type    = preg_replace( '/^core\//', '', $block->blockName );
 
 			$block_attributes = '';
 			if ( self::has_non_empty_attributes( $block ) ) {
 				$block_attributes = ' ' . json_encode( $block->attrs, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
 			}
-			$content .= self::GUTENBERG_OPENING_START . $block_type . $block_attributes . ' -->';
+			$content .= self::GUTENBERG_OPENING_START . $block_type . $block_attributes . ' ';
 
-			$content .= self::render_inner_HTML( $block );
-
-			$content .= self::GUTENBERG_CLOSING_START . $block_type . ' -->';
+			if ( $block_content ) {
+				$content .= '-->' . $block_content . self::GUTENBERG_CLOSING_START . $block_type . ' -->';
+			} else {
+				$content .= '/-->';
+			}
 		} else {
 			$content = wpautop( $block->innerHTML );
 		}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -748,6 +748,23 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 		);
 	}
 
+	/**
+	 * @test
+	 * @group wpmlcore-7038
+	 */
+	public function it_should_render_self_closing_block() {
+		$block               = \Mockery::mock( 'WP_Block_Parser_Block' );
+		$block->blockName    = 'acf/testimonials';
+		$block->attrs        = [ 'foo' => 'bar' ];
+		$block->innerHTML    = '';
+		$block->innerContent = [];
+
+		$this->assertEquals(
+			'<!-- wp:' . $block->blockName . ' ' . json_encode( $block->attrs ) . ' /-->',
+			WPML_Gutenberg_Integration::render_block( $block )
+		);
+	}
+
 	public function get_subject( $config_option = null, $strings_registration = null ) {
 		if ( ! $config_option ) {
 			$config_option = \Mockery::mock( 'WPML_Gutenberg_Config_Option' );


### PR DESCRIPTION
FTR, WP 5.3.1 comes with a new function `get_comment_delimited_block_content` but it has several glitches and I am not sure it covers all the little fixes that we added recently. Maybe we can replace our code with this in the future, but not now.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7038