### PR TITLE
Convert and fallback to original if element is displayed as translated

### DIFF
--- a/src/IdsInBlock/Base.php
+++ b/src/IdsInBlock/Base.php
@@ -15,19 +15,45 @@ class Base {
 
 	/**
 	 * @param array|int $ids
-	 * @param string    $elementType
+	 * @param string    $elementSlug e.g. "page", "category", ...
+	 * @param string    $elementType "post" or "taxonomy".
 	 *
 	 * @return array|int
 	 */
-	public static function convertIds( $ids, $elementType ) {
-		$getTranslation = function( $id ) use ( $elementType ) {
-			return (int) wpml_object_id_filter( $id, $elementType );
+	public static function convertIds( $ids, $elementSlug, $elementType ) {
+		$isDisplayAsTranslated = self::isDisplayedAsTranslated( $elementSlug, $elementType );
+
+		$getTranslation = function ( $id ) use ( $elementSlug, $isDisplayAsTranslated ) {
+			$newId = (int) wpml_object_id_filter( $id, $elementSlug );
+
+			if ( ! $newId && $isDisplayAsTranslated ) {
+				return (int) $id;
+			}
+
+			return $newId;
 		};
 
 		if ( is_array( $ids ) ) {
-			return wpml_collect( $ids )->map( $getTranslation )->toArray();
+			return wpml_collect( $ids )
+				->map( $getTranslation )
+				->toArray();
 		}
 
 		return $getTranslation( $ids );
+	}
+
+	/**
+	 * @param string $slug
+	 * @param string $type
+	 *
+	 * @return bool
+	 */
+	private static function isDisplayedAsTranslated( $slug, $type ) {
+		/** @var \SitePress $sitepress */
+		global $sitepress;
+
+		return 'post' === $type
+			? $sitepress->is_display_as_translated_post_type( $slug )
+			: $sitepress->is_display_as_translated_taxonomy( $slug );
 	}
 }

--- a/src/IdsInBlock/BlockAttributes.php
+++ b/src/IdsInBlock/BlockAttributes.php
@@ -17,6 +17,7 @@ class BlockAttributes extends Base {
 			if ( isset( $block['attrs'][ $name ] ) ) {
 				$block['attrs'][ $name ] = self::convertIds(
 					$block['attrs'][ $name ],
+					$attributeConfig['slug'],
 					$attributeConfig['type']
 				);
 			}

--- a/src/IdsInBlock/TagAttributes.php
+++ b/src/IdsInBlock/TagAttributes.php
@@ -27,7 +27,7 @@ class TagAttributes extends Base {
 
 			foreach ( $nodes as $node ) {
 				/** @var \DOMNode $node */
-				$ids = implode( ',' , self::convertIds( explode( ',', $node->nodeValue ), $attributeConfig['type'] ) );
+				$ids = implode( ',' , self::convertIds( explode( ',', $node->nodeValue ), $attributeConfig['slug'], $attributeConfig['type'] ) );
 				$blockObject = \WPML_Gutenberg_Integration::sanitize_block( $block );
 				$block = (array) HTML::update_string_in_innerContent( $blockObject, $node, $ids );
 				$domHandler->setElementValue( $node, $ids );

--- a/tests/phpunit/tests/IdsInBlock/TestTagAttributes.php
+++ b/tests/phpunit/tests/IdsInBlock/TestTagAttributes.php
@@ -7,18 +7,27 @@ namespace WPML\PB\Gutenberg\ConvertIdsInBlock;
  */
 class TestTagAttributes extends \OTGS_TestCase {
 
+	public function tearDown() {
+		unset( $GLOBALS['sitepress'] );
+		parent::tearDown();
+	}
+
 	/**
 	 * @test
 	 */
 	public function itShouldConvert() {
 		$id          = 123;
 		$convertedId = 456;
-		$class = 'my-class';
-		$attribute = 'data-my-id';
-		$type = 'page';
+		$class       = 'my-class';
+		$attribute   = 'data-my-id';
+		$slug        = 'page';
 
 		$config = [
-			[ 'xpath' => '//*[contains(@class, "' . $class . '")]/@' . $attribute, 'type' => $type ],
+			[
+				'xpath' => '//*[contains(@class, "' . $class . '")]/@' . $attribute,
+				'slug'  => $slug,
+				'type'  => 'post',
+			],
 		];
 
 		$getBlock = function( $id ) use ( $class, $attribute ) {
@@ -36,13 +45,27 @@ class TestTagAttributes extends \OTGS_TestCase {
 		$block         = $getBlock( $id );
 		$expectedBlock = $getBlock( $convertedId );
 
-		\WP_Mock::userFunction( 'wpml_object_id_filter', [
-			'args'   => [ $id, $type ],
-			'return' => $convertedId,
-		] );
+		$this->mockConvertIds( $id, $convertedId, $slug );
 
 		$subject = new TagAttributes( $config );
 
 		$this->assertEquals( $expectedBlock, $subject->convert( $block ) );
+	}
+
+	private function mockConvertIds( $id, $convertedId, $slug ) {
+		global $sitepress;
+
+		$sitepress = $this->getMockBuilder( '\SitePress' )
+			->setMethods( [ 'is_display_as_translated_post_type' ] )
+			->disableOriginalConstructor()->getMock();
+
+		$sitepress->method( 'is_display_as_translated_post_type' )
+			->with( $slug )
+			->willReturn( false );
+
+		\WP_Mock::userFunction( 'wpml_object_id_filter', [
+			'args'   => [ $id, $slug ],
+			'return' => $convertedId,
+		] );
 	}
 }


### PR DESCRIPTION
If the ID conversion returns a falsy value and the element is displayed
as translated, we will use the original ID.

https://onthegosystems.myjetbrains.com/youtrack/issue/wcml-3082