### PR TITLE
Handle Gutenberg Block defined as LINK type in wpml-config.xml

### DIFF
--- a/src/strings-in-block/class-base.php
+++ b/src/strings-in-block/class-base.php
@@ -87,7 +87,7 @@ abstract class Base implements StringsInBlock {
 		if ( strpos( $string, '<' ) !== false ) {
 			$type = 'VISUAL';
 		}
-		if ( strpos( $string, '://' ) !== false ) {
+		if ( filter_var( $string, FILTER_VALIDATE_URL ) ) {
 			$type = 'LINK';
 		}
 

--- a/src/strings-in-block/class-base.php
+++ b/src/strings-in-block/class-base.php
@@ -87,6 +87,9 @@ abstract class Base implements StringsInBlock {
 		if ( strpos( $string, '<' ) !== false ) {
 			$type = 'VISUAL';
 		}
+		if ( strpos( $string, '://' ) !== false ) {
+			$type = 'LINK';
+		}
 
 		return $type;
 	}

--- a/tests/phpunit/tests/strings-in-block/TestBase.php
+++ b/tests/phpunit/tests/strings-in-block/TestBase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WPML\PB\Gutenberg\StringsInBlock;
+
+use function rand_long_str;
+
+/**
+ * @group page-builders
+ * @group gutenberg
+ * @group strings-in-block
+ */
+class TestBase extends \OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dpGetsStringType
+	 * @group wpmlcore-7069
+	 */
+	public function itGetsStringType( $string, $expectedType ) {
+		$this->assertEquals( $expectedType, Base::get_string_type( $string ) );
+	}
+
+	public function dpGetsStringType() {
+		return [
+			'simple string'               => [ 'some simple string', 'LINE' ],
+			'string including line break' => [ "Hello\nThere", 'AREA' ],
+			'long string'                 => [ rand_long_str( Base::LONG_STRING_LENGTH + 1 ), 'AREA' ],
+			'string with HTML tag'        => [ 'Hello <b>There</b>', 'VISUAL' ],
+			'with a simple URL'           => [ 'http://example.com', 'LINK' ],
+			'string with text and URL'    => [ 'A string containing a URL http://example.com', 'LINE' ],
+		];
+	}
+}


### PR DESCRIPTION
When the link is external, it is set by other logic to Line
However, if the link is internal, it shoudl be translated by WPML and
it should be set to LINK type

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7069