### PR TITLE
Rollback changes made in

### DIFF
--- a/src/strings-in-block/dom-handler/dom-handle.php
+++ b/src/strings-in-block/dom-handler/dom-handle.php
@@ -29,9 +29,17 @@ abstract class DOMHandle {
 		$dom = new \DOMDocument();
 		\libxml_use_internal_errors( true );
 		$html = mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' );
-		$dom->loadHTML( '<div>' . $html . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		$dom->loadHTML( '<div>' . $html . '</div>' );
 		\libxml_clear_errors();
 
+		// Remove doc type and <html> <body> wrappers
+		$dom->removeChild( $dom->doctype );
+
+		/**
+		 * $dom->firstChild->firstChild->firstChild is node that we are intersted in (without body tags).
+		 * $dom->firstChild Old node that we are replacing
+		 */
+		$dom->replaceChild( $dom->firstChild->firstChild->firstChild, $dom->firstChild );
 		return $dom;
 	}
 


### PR DESCRIPTION
https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/pull/74

related with refactoring of removing DTD and html/body tags.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7270