### PR TITLE
Fix xpath config parsing when a block has only 1 element and contains a type attribute

### DIFF
--- a/src/XPath.php
+++ b/src/XPath.php
@@ -14,8 +14,6 @@ class XPath {
 	 * @return array
 	 */
 	public static function normalize( $data ) {
-		$data = is_string( $data ) ? array( 'value' => $data ) : $data;
-
 		if ( isset( $data['attr']['type'] ) ) {
 			$data['value'] = [
 				'value' => $data['value'],

--- a/src/class-wpml-gutenberg-config-option.php
+++ b/src/class-wpml-gutenberg-config-option.php
@@ -43,7 +43,7 @@ class WPML_Gutenberg_Config_Option {
 			$block_name                     = $block_config['attr']['type'];
 			$blocks[ $block_name ]['xpath'] = array();
 
-			foreach ( $block_config['xpath'] as $xpaths ) {
+			foreach ( $this->normalize_key_data( $block_config['xpath'] ) as $xpaths ) {
 				$xpaths                         = XPath::normalize( $xpaths );
 				$blocks[ $block_name ]['xpath'] = array_merge( $blocks[ $block_name ]['xpath'], array_values( $xpaths ) );
 

--- a/tests/phpunit/tests/XPathTest.php
+++ b/tests/phpunit/tests/XPathTest.php
@@ -7,14 +7,6 @@ class XPathTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @test
 	 */
-	public function it_normalizes_string() {
-		$string = 'data';
-		$this->assertEquals( [ 'value' => $string ], XPath::normalize( $string ) );
-	}
-
-	/**
-	 * @test
-	 */
 	public function it_normalizes_array() {
 		$array = [ 'value' => 'data' ];
 		$this->assertEquals( $array, XPath::normalize( $array ) );

--- a/tests/phpunit/tests/test-wpml-gutenberg-config-option.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-config-option.php
@@ -93,6 +93,58 @@ class Test_WPML_Gutenberg_Integration_Config_Option extends OTGS_TestCase {
 		$subject->update_from_config( $config_settings );
 	}
 
+
+
+	/**
+	 * @test
+	 * @group wpmlcore-7069
+	 */
+	public function it_updates_option_from_config_with_only_one_xpath_containing_type_attribute() {
+		$subject = new WPML_Gutenberg_Config_Option();
+
+		$blockType = 'block/type';
+		$xpath     = '//my/xpath';
+		$type      = 'link';
+
+		$blockDate = [
+			'attr'  => [ 'type' => $blockType, 'translate' => '1' ],
+			'xpath' => [
+				// For a single element, it's not wrapped in a array
+				// For multiple elements, each is wrapped in an array.
+				'value' => $xpath,
+				'attr'  => [ 'type' => $type ],
+			],
+		];
+
+		$expectedBlockConfig = [
+			'xpath' => [
+				[
+					'value' => $xpath,
+					'type'  => strtoupper( $type ),
+				],
+			],
+		];
+
+		$configSettings = [
+			'wpml-config' => [
+				'gutenberg-blocks' => [
+					'gutenberg-block' => [ $blockDate ],
+				],
+			],
+		];
+
+		\WP_Mock::userFunction( 'update_option',
+			[
+				'times' => 1,
+				'args'  => [
+					WPML_Gutenberg_Config_Option::OPTION,
+					[ $blockType => $expectedBlockConfig ],
+				],
+			] );
+
+		$subject->update_from_config( $configSettings );
+	}
+
 	/**
 	 * @test
 	 * @group wpmlcore-6606


### PR DESCRIPTION
The array produced from the XML config does not always have the same
shape if it has a single element or several ones.

1. single element:

```php
$xpath = [
    'value' => '//my/xpath',
    'attr'  => [ 'type' => 'link' ],
];
```

2. multiple elements:

```php
$xpath = [
    [
        'value' => '//my/xpath1',
        'attr'  => [ 'type' => 'link' ],
    ],
    [
        'value' => '//my/xpath2',
        'attr'  => [ 'type' => 'link' ],
    ],
];
```

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7069

**Important note:** I am trying to understand what has changed in the previous PR (https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/pull/65/files#diff-48a751ae78075d37ac563a6f4ca23b4bR47) because we were still applying the data normalization at the same place... I suspect that the data shape changed when we added the `type` attribute to the config `xsd` file (se [here](https://git.onthegosystems.com/wpml/sitepress-multilingual-cms/-/merge_requests/2489/diffs#c30cd42a1989b53a111f60442d1317b76ce3ae7e_278_277)). 