### PR TITLE
Delegate also string registration if no string is found in a block

### DIFF
--- a/tests/phpunit/tests/test-wpml-gutenberg-string-registration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-string-registration.php
@@ -403,7 +403,7 @@ class Test_WPML_Gutenberg_String_Registration extends OTGS_TestCase {
 	 * @test
 	 * @group wpmlcore-6325
 	 */
-	public function it_does_not_register_strings_that_are_handled_by_other_page_builer() {
+	public function it_does_not_register_strings_that_are_handled_by_other_page_builder() {
 		$post = self::createPost();
 
 		$package = array(


### PR DESCRIPTION
It's not possible to check if a filter was called (at least not with `10up/wp_mock` on version `0.2.0` which is the last version compatible with PHP 5.6), I so don't have unit test for this change. But the whole issue will definitely require a CC test.

@brucepearson, please check this.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7375