### PR TITLE
Fix inner reusable block conversion

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: nanasess/setup-php@master
+        with:
+          php-version: '7.4'
+
       - name: Set github token for composer
         run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
 

--- a/src/reusable-blocks/class-integration.php
+++ b/src/reusable-blocks/class-integration.php
@@ -2,6 +2,8 @@
 
 namespace WPML\PB\Gutenberg\ReusableBlocks;
 
+use WPML\FP\Fns;
+
 class Integration implements \WPML\PB\Gutenberg\Integration {
 
 	/** @var Translation $translation */
@@ -13,6 +15,7 @@ class Integration implements \WPML\PB\Gutenberg\Integration {
 
 	public function add_hooks() {
 		add_filter( 'render_block_data', [ $this, 'convertReusableBlock' ] );
+		add_filter( 'render_block', Fns::withoutRecursion( Fns::identity(), [ $this, 'reRenderInnerReusableBlock' ] ), 10, 2 );
 	}
 
 	/**
@@ -24,5 +27,29 @@ class Integration implements \WPML\PB\Gutenberg\Integration {
 	 */
 	public function convertReusableBlock( array $block ) {
 		return $this->translation->convertBlock( $block );
+	}
+
+	/**
+	 * The filter hook `render_block_data` applies only for root blocks,
+	 * nested blocks are not passing through this hook.
+	 * That's why we need to re-render reusable nested blocks.
+	 *
+	 * @param string $blockContent
+	 * @param array  $block
+	 *
+	 * @return string
+	 */
+	public function reRenderInnerReusableBlock( $blockContent, $block ) {
+		$originalId = Blocks::getReusableId( $block );
+
+		if ( $originalId ) {
+			$convertedBlock = $this->translation->convertBlock( $block );
+
+			if ( Blocks::getReusableId( $convertedBlock ) !== $originalId ) {
+				return render_block( $convertedBlock );
+			}
+		}
+
+		return $blockContent;
 	}
 }


### PR DESCRIPTION
The filter hook `render_block_data` applies only for root
blocks, nested blocks are not passing through this hook.

That's why we need to re-render reusable nested blocks. For performance
concerns, we will re-render only if the converted block is different
from the original one (i.e. different ID).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7651