### PR TITLE
Fix incorrect loading context for block widgets integration

### DIFF
--- a/src/class-wpml-gutenberg-integration-factory.php
+++ b/src/class-wpml-gutenberg-integration-factory.php
@@ -23,16 +23,18 @@ class WPML_Gutenberg_Integration_Factory {
 				$integrations->add(
 					make( '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration' )
 				);
-			} else {
-				$integrations->add(
-					make( \WPML\PB\Gutenberg\Widgets\Block\DisplayTranslation::class )
-				);
 			}
+		}
 
+		if ( ! is_admin() ) {
 			$integrations->add(
-				make( \WPML\PB\Gutenberg\Widgets\Block\RegisterStrings::class )
+				make( \WPML\PB\Gutenberg\Widgets\Block\DisplayTranslation::class )
 			);
 		}
+
+		$integrations->add(
+			make( \WPML\PB\Gutenberg\Widgets\Block\RegisterStrings::class )
+		);
 
 		return $integrations;
 	}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration-factory.php
@@ -43,6 +43,8 @@ class Test_WPML_Gutenberg_Integration_Factory extends OTGS_TestCase {
 
 		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\Integration', '\WPML\PB\Gutenberg\Integration' );
 		$this->expect_container_make( 0, '\WPML\PB\Gutenberg\ReusableBlocks\AdminIntegration', '\WPML\PB\Gutenberg\Integration' );
+		$this->expect_container_make( (int) ! $is_admin, \WPML\PB\Gutenberg\Widgets\Block\DisplayTranslation::class, '\WPML\PB\Gutenberg\Integration' );
+		$this->expect_container_make( 1, \WPML\PB\Gutenberg\Widgets\Block\RegisterStrings::class, '\WPML\PB\Gutenberg\Integration' );
 
 		$factory = new WPML_Gutenberg_Integration_Factory();
 


### PR DESCRIPTION
This was wrongly wrapped inside the `if ( $this->should_translate_reusable_blocks() ) {` block.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlst-2470