### PR TITLE
Add support for media translation of block widgets

### DIFF
--- a/src/Widgets/Block/DisplayTranslation.php
+++ b/src/Widgets/Block/DisplayTranslation.php
@@ -19,6 +19,12 @@ class DisplayTranslation implements \IWPML_Frontend_Action, \WPML\PB\Gutenberg\I
 		     ->then( spreadArgs( function ( $content ) use ( $getStringsFromMOFile ) {
 			     $strings = $getStringsFromMOFile( \get_locale() );
 
+			     $imageTranslator = make( \WPML_Media_Translated_Images_Update::class );
+
+			     if ( $imageTranslator ) {
+				     $content = $imageTranslator->replace_images_with_translations( $content, Languages::getCurrentCode() );
+			     }
+
 			     return make( \WPML_Gutenberg_Integration::class )
 				     ->replace_strings_in_blocks( $content, $strings, Languages::getCurrentCode() );
 		     } ) );

--- a/tests/phpunit/tests/Widgets/Block/DisplayTranslationTest.php
+++ b/tests/phpunit/tests/Widgets/Block/DisplayTranslationTest.php
@@ -65,4 +65,43 @@ class DisplayTranslationTest extends \OTGS_TestCase {
 		$actualResult = $this->runFilter( 'widget_block_content', $content );
 		$this->assertEquals( $translatedContent, $actualResult );
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_displays_translated_widgets_with_translated_images() {
+		$content                     = 'Some content my string 1 and <img href="original_url">.';
+		$contentWithTranslatedImages = 'Some content my string 1 and <img href="converted_url">.';
+		$translatedContent           = 'Some content fr my string 1 and <img href="converted_url">.';
+
+		$locale = 'fr_FR';
+		\WP_Mock::userFunction( 'get_locale', [ 'return' => $locale ] );
+
+		$this->setCurrentLanguage( 'fr' );
+		$this->setStringsInMOFile( Strings::DOMAIN, $locale, [
+			'my string 1' => 'fr my string 1',
+		] );
+
+		$strings = [
+			'my string 1' => [
+				'fr' => [ 'value' => 'fr my string 1', 'status' => ICL_STRING_TRANSLATION_COMPLETE ]
+			],
+		];
+
+		$this->mockMake( \WPML_Media_Translated_Images_Update::class )
+		     ->shouldReceive( 'replace_images_with_translations' )
+		     ->with( $content, 'fr' )
+		     ->andReturn( $contentWithTranslatedImages );
+
+		$this->gutenbergIntegration
+			->shouldReceive( 'replace_strings_in_blocks' )
+			->with( $contentWithTranslatedImages, $strings, 'fr' )
+			->andReturn( $translatedContent );
+
+		$subject = new DisplayTranslation();
+		$subject->add_hooks();
+
+		$actualResult = $this->runFilter( 'widget_block_content', $content );
+		$this->assertEquals( $translatedContent, $actualResult );
+	}
 }


### PR DESCRIPTION
The tests are failing because it requires a small adjustment in `makeMock` (https://git.onthegosystems.com/wpml-packages/core-api/-/merge_requests/77).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8670