### PR TITLE
Fix/handle multitag wrap

### DIFF
--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -292,12 +292,15 @@ class WPML_Gutenberg_Integration implements \WPML\PB\Gutenberg\Integration {
 
 				if ( count( $matches ) === 1 ) {
 					$parts = explode( $matches[0], $inner_HTML );
-					if ( count( $parts ) === 2 ) {
+					if ( count( $parts ) >= 2 ) {
+						$partsRight = array_slice( $parts, 1 );
 						$match_mid_point = 1 + ( mb_strlen( $matches[0] ) - 3 ) / 2;
 						// This is the first ">" char plus half the remaining between the tags
 
-						$parts[0] .= mb_substr( $matches[0], 0, $match_mid_point );
-						$parts[1] = mb_substr( $matches[0], $match_mid_point ) . $parts[1];
+						$parts = array(
+							$parts[0] . mb_substr( $matches[0], 0, $match_mid_point ),
+							mb_substr( $matches[0], $match_mid_point ) . implode( '></', $partsRight ),
+						);
 					}
 				}
 				break;

--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -291,16 +291,13 @@ class WPML_Gutenberg_Integration implements \WPML\PB\Gutenberg\Integration {
 				preg_match( '#>\s*</#', $inner_HTML, $matches );
 
 				if ( count( $matches ) === 1 ) {
-					$parts = explode( $matches[0], $inner_HTML );
-					if ( count( $parts ) >= 2 ) {
-						$partsRight = array_slice( $parts, 1 );
+					$parts = explode( $matches[0], $inner_HTML, 2 );
+					if ( count( $parts ) === 2 ) {
 						$match_mid_point = 1 + ( mb_strlen( $matches[0] ) - 3 ) / 2;
 						// This is the first ">" char plus half the remaining between the tags
 
-						$parts = array(
-							$parts[0] . mb_substr( $matches[0], 0, $match_mid_point ),
-							mb_substr( $matches[0], $match_mid_point ) . implode( $matches[0], $partsRight ),
-						);
+						$parts[0] .= mb_substr( $matches[0], 0, $match_mid_point );
+						$parts[1] = mb_substr( $matches[0], $match_mid_point ) . $parts[1];
 					}
 				}
 				break;

--- a/src/class-wpml-gutenberg-integration.php
+++ b/src/class-wpml-gutenberg-integration.php
@@ -299,7 +299,7 @@ class WPML_Gutenberg_Integration implements \WPML\PB\Gutenberg\Integration {
 
 						$parts = array(
 							$parts[0] . mb_substr( $matches[0], 0, $match_mid_point ),
-							mb_substr( $matches[0], $match_mid_point ) . implode( '></', $partsRight ),
+							mb_substr( $matches[0], $match_mid_point ) . implode( $matches[0], $partsRight ),
 						);
 					}
 				}

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -454,7 +454,8 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 				"<div class=\"wp-block-column\">\r\n\r\n</div>",
 				"<div class=\"wp-block-column\">\r\n",
 				"\r\n</div>"
-			)
+			),
+			array( '<div class="wp-block-column"><b><span></span></b></div>', '<div class="wp-block-column"><b><span>', '</span></b></div>' )
 		);
 	}
 


### PR DESCRIPTION
Fix problem with inner html like: `<a><b><c></c></b></a>`.  Since `></`  is the first match in the center, as `></`, the explode() will create many parts for b and a. This patch limit to 2 parts, to make `<a><b><c>` and `</c></b></a>`. 

In render_inner_HTML_with_guess_parts, it always assume that the array is of length 2 (doesn't use anything else).

(edit from Pierre: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8769)