### PR TITLE
feat(gutenberg): fix problem with innerContent escaped attribute when…

### DIFF
--- a/src/strings-in-block/class-html.php
+++ b/src/strings-in-block/class-html.php
@@ -135,11 +135,11 @@ class HTML extends Base {
 
 		if ( $element instanceof \DOMAttr ) {
 			$search_value = preg_quote( htmlspecialchars( $element->nodeValue ), '/' );
-			$search = '/(")(' . $search_value . ')(")/';
-			$translation = htmlspecialchars( $translation );
+			$search       = '/(")(' . $search_value . ')(")/';
+			$translation  = htmlspecialchars( $translation );
 		} else {
 			$search_value = preg_quote( $element->nodeValue, '/' );
-			$search = '/(>)(' . $search_value . ')(<)/';
+			$search       = '/(>)(' . $search_value . ')(<)/';
 		}
 
 		foreach ( $block->innerContent as &$inner_content ) {

--- a/src/strings-in-block/class-html.php
+++ b/src/strings-in-block/class-html.php
@@ -133,11 +133,12 @@ class HTML extends Base {
 			return $block;
 		}
 
-		$search_value = preg_quote( $element->nodeValue, '/' );
-
 		if ( $element instanceof \DOMAttr ) {
+			$search_value = preg_quote( htmlspecialchars( $element->nodeValue ), '/' );
 			$search = '/(")(' . $search_value . ')(")/';
+			$translation = htmlspecialchars( $translation );
 		} else {
+			$search_value = preg_quote( $element->nodeValue, '/' );
 			$search = '/(>)(' . $search_value . ')(<)/';
 		}
 

--- a/src/strings-in-block/class-html.php
+++ b/src/strings-in-block/class-html.php
@@ -134,9 +134,9 @@ class HTML extends Base {
 		}
 
 		if ( $element instanceof \DOMAttr ) {
-			$search_value = preg_quote( htmlspecialchars( $element->nodeValue ), '/' );
+			$search_value = preg_quote( esc_attr( $element->nodeValue ), '/' );
 			$search       = '/(")(' . $search_value . ')(")/';
-			$translation  = htmlspecialchars( $translation );
+			$translation  = esc_attr( $translation );
 		} else {
 			$search_value = preg_quote( $element->nodeValue, '/' );
 			$search       = '/(>)(' . $search_value . ')(<)/';

--- a/tests/phpunit/tests/test-wpml-gutenberg-integration.php
+++ b/tests/phpunit/tests/test-wpml-gutenberg-integration.php
@@ -580,8 +580,8 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 		$title             = 'My title';
 		$title_translation = 'DE My title';
 
-		$attr             = 'My Attribute';
-		$attr_translation = 'DE My Attribute';
+		$attr             = 'My Attribute with "quotes".';
+		$attr_translation = 'DE My Attribute with "quotes".';
 
 		$paragraph_text             = 'My paragraph.';
 		$paragraph_text_translation = 'DE My paragraph.';
@@ -613,7 +613,13 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 		$block_paragraph->innerHTML    = '<p>' . $paragraph_text . '</p>';
 		$block_paragraph->innerContent = [ $block_paragraph->innerHTML ];
 
-		$parent_contents = $this->get_parent_block_contents( $title, $attr );
+		$esc_attr = function( $value ) {
+			return htmlspecialchars( $value );
+		};
+
+		\WP_Mock::userFunction( 'esc_attr', [ 'return' => $esc_attr ] );
+
+		$parent_contents = $this->get_parent_block_contents( $title, $esc_attr( $attr ) );
 
 		$parent_block               = \Mockery::mock( 'WP_Block_Parser_Block' );
 		$parent_block->blockName    = $core_parent_block_name;
@@ -634,7 +640,7 @@ class Test_WPML_Gutenberg_Integration extends OTGS_TestCase {
 		);
 
 		$rendered_paragraph          = $this->get_content_with_block_meta_data( $p_block_name, '<p>' . $paragraph_text_translation . '</p>', true );
-		$translated_parent_contents  = $this->get_parent_block_contents( $title_translation, $attr_translation );
+		$translated_parent_contents  = $this->get_parent_block_contents( $title_translation, $esc_attr( $attr_translation ) );
 		$translated_inner_content    = $translated_parent_contents[0] . $rendered_paragraph . $translated_parent_contents[1];
 		$rendered_translated_content = $this->get_content_with_block_meta_data( $parent_block_name, $translated_inner_content, true);
 


### PR DESCRIPTION
This follow https://github.com/OnTheGoSystems/wpml-page-builders-gutenberg/pull/102 discussion. 

wpml-config.xml:
```
<wpml-config>
<gutenberg-blocks>
    <gutenberg-block type="okam/okam-tabs" translate="1">
        <key name="tabsArray" />
        <key name="tabsAriaLabel" />
        <xpath>//okam-tabs/@tabs-array</xpath>
        <xpath>//okam-tabs/@tabs-aria-label</xpath>
    </gutenberg-block>
</gutenberg-blocks>
</wpml-config>
```
wp_posts.post_content: 
```
<!-- wp:okam/okam-tabs {"tabsArray":"[\u0022INNOVATION EN 9\u0022, \u0022DÉVELOPPEMENT DURABLE B\u0022, \u0022CONFORMITÉ C\u0022, \u0022RÉSEAU MONDIAL2 D\u0022]","translatedWithWPMLTM":"1"} -->
<okam-tabs class="wp-block-okam-okam-tabs" tabs-array="[&quot;INNOVATION EN 9&quot;, &quot;DÉVELOPPEMENT DURABLE B&quot;, &quot;CONFORMITÉ C&quot;, &quot;RÉSEAU MONDIAL2 D&quot;]" tabs-aria-label="Go to tab en 2">
<div>some content</div>
<div>some content</div>
<div>some content</div>
<div>some content</div>
</okam-tabs>
<!-- /wp:okam/okam-tabs -->
```

When trying to replace a translation with ", < or > inside an attribute, the element->nodeValue and the translation don't have the html encoding (`&quot; &lt; or &gt;`) that are inside the $block->innerContent items.
Converting them in the search_value and the translation will result in a good preg_replace for inner_content.

TODO: maybe add a test and check if any encoding parameter is needed inside htmlspecialchars()

(edit from Pierre: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8769)